### PR TITLE
Add ApiClient class

### DIFF
--- a/src/client/__tests__/calculate-updates.spec.js
+++ b/src/client/__tests__/calculate-updates.spec.js
@@ -105,6 +105,92 @@ describe( 'calculateUpdates', () => {
 		] );
 	} );
 
+	it( 'should not return an update if stale but requested and not yet timed out.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 10 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 121 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [] );
+	} );
+
+	it( 'should return an update if both stale, requested and timed out.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 3 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 121 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [
+			{ endpointPath: [ 'things' ], params: { page: 1, perPage: 3 } },
+		] );
+	} );
+
+	it( 'should not return an update if timed out, but no longer stale.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 3 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 3 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [] );
+	} );
+
 	it( 'should return an empty set if nothing needs an update', () => {
 		const requirementsByEndpoint = {
 			things: {

--- a/src/client/__tests__/calculate-updates.spec.js
+++ b/src/client/__tests__/calculate-updates.spec.js
@@ -229,3 +229,4 @@ describe( 'calculateUpdates', () => {
 		expect( nextUpdate / 1000 ).toBeCloseTo( -( 1 * SECOND ) / 1000, 1 );
 	} );
 } );
+

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -104,5 +104,17 @@ describe( 'ApiClient', () => {
 	} );
 
 	it( 'should map selectors to new state when it changes', () => {
+		const apiClient = new ApiClient( api, '123' );
+		const state1 = {
+			stuff: { 1: { data: 'abc' }, 2: { data: 'def' } },
+		};
+		const state2 = {
+			stuff: { ...state1.stuff, 3: { data: 'ghi' } },
+		};
+		apiClient.setState( state1, null );
+		expect( apiClient.selectors.getStuff( 2, {} ) ).toEqual( 'def' );
+
+		apiClient.setState( state2, null );
+		expect( apiClient.selectors.getStuff( 3, {} ) ).toEqual( 'ghi' );
 	} );
 } );

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -1,0 +1,108 @@
+import ApiClient from '../index';
+import { SECOND } from '../../utils/constants';
+
+describe( 'ApiClient', () => {
+	const api = {
+		methods: {},
+		endpoints: {
+			stuff: {
+				fetchByIds: { method: 'get', params: { include: 'ids' } },
+			},
+		},
+		selectors: {
+			getStuff: ( apiClientState, requireData ) => ( stuffId, requirements ) => {
+				requireData( 'stuff', [ stuffId ], requirements );
+				const stuff = apiClientState.stuff[ stuffId ];
+				return stuff ? stuff.data : null;
+			}
+		},
+	};
+
+	it( 'should initialize to empty state', () => {
+		const apiClient = new ApiClient( api, '123' );
+		expect( apiClient.state ).toBe( null );
+	} );
+
+	describe( 'setState', () => {
+		it( 'should set state initially', () => {
+			const apiClient = new ApiClient( api, '123' );
+			const state = {
+				stuff: { },
+			};
+			apiClient.setState( state, null );
+			expect( apiClient.state ).toBe( state );
+		} );
+
+		it( 'should do nothing when the state has not changed', () => {
+			const state = {
+				stuff: { },
+			};
+			const apiClient = new ApiClient( api, '123', state );
+			apiClient.setState( state, null );
+			expect( apiClient.state ).toBe( state );
+		} );
+
+		it( 'should set state when state has changed', () => {
+			const state1 = {
+				stuff: { 1: { data: 'abc' }, 2: { data: 'def' } },
+			};
+			const state2 = {
+				stuff: { ...state1.stuff, 3: { data: 'ghi' } },
+			};
+			const apiClient = new ApiClient( api, '123', state1 );
+			apiClient.setState( state2, null );
+			expect( apiClient.state ).toBe( state2 );
+		} );
+	} );
+
+	describe( 'requireData', () => {
+		it( 'should set requirements for an item', () => {
+			const reqs = { freshness: 90 * SECOND, timeout: 20 * SECOND };
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.updateRequirements = () => {}; // Prevent API method calls.
+			apiClient.requireData( 'stuff', [ 1 ], reqs );
+			expect( apiClient.clientRequirements.stuff[ 1 ] ).toEqual( reqs );
+		} );
+
+		it( 'should not call updateReqiurements when no requirements have changed', () => {
+			const reqs = { freshness: 90 * SECOND, timeout: 20 * SECOND };
+			const apiClient = new ApiClient( api, '123' );
+
+			apiClient.updateRequirements = jest.fn();
+			apiClient.requireData( 'stuff', [ 1 ], reqs );
+			expect( apiClient.updateRequirements ).toHaveBeenCalled();
+
+			apiClient.updateRequirements = jest.fn();
+			apiClient.requireData( 'stuff', [ 1 ], reqs );
+			expect( apiClient.updateRequirements ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should call updateRequirements when a new requirement is added', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.updateRequirements = jest.fn();
+			apiClient.requireData( 'stuff', [ 1 ], { freshness: 90 * SECOND } );
+			expect( apiClient.updateRequirements ).toHaveBeenCalled();
+		} );
+
+		it( 'should call updateRequirements when a requirement is changed', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.updateRequirements = jest.fn();
+			apiClient.requireData( 'stuff', [ 1 ], { freshness: 90 * SECOND } );
+			apiClient.requireData( 'stuff', [ 1 ], { freshness: 80 * SECOND } );
+			expect( apiClient.updateRequirements ).toHaveBeenCalledTimes( 2 );
+		} );
+	} );
+
+	it( 'should map selectors to current state', () => {
+		const apiClient = new ApiClient( api, '123' );
+		const state = {
+			stuff: { 1: { data: 'abc' }, 2: { data: 'def' } },
+		};
+		apiClient.setState( state, null );
+		const { getStuff } = apiClient.selectors;
+		expect( getStuff( 2, {} ) ).toEqual( 'def' );
+	} );
+
+	it( 'should map selectors to new state when it changes', () => {
+	} );
+} );

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -86,14 +86,15 @@ describe( 'ApiClient', () => {
 	} );
 
 	describe( '#setComponentData', () => {
-		it( 'should select data for component from last state set', () => {
-			const api = {
-				methods: {},
-				endpoints: {},
-				selectors: thingSelectors,
-			};
+		const api = {
+			methods: {},
+			endpoints: {},
+			selectors: thingSelectors,
+		};
 
-			const component = () => {};
+		const component = () => {};
+
+		it( 'should select data for component from last state set', () => {
 			const apiClient = new ApiClient( api, '123' );
 			apiClient.setState( thing1ClientState );
 
@@ -103,13 +104,6 @@ describe( 'ApiClient', () => {
 		} );
 
 		it( 'should set requirements for component', () => {
-			const api = {
-				methods: {},
-				endpoints: {},
-				selectors: thingSelectors,
-			};
-
-			const component = () => {};
 			const apiClient = new ApiClient( api, '123' );
 			apiClient.setState( thing1ClientState );
 
@@ -124,6 +118,90 @@ describe( 'ApiClient', () => {
 					endpoint: [ 'things', 1 ],
 				}
 			] );
+		} );
+	} );
+
+	describe( '#updateRequirementsData', () => {
+		const api = {
+			methods: {},
+			endpoints: {},
+			selectors: thingSelectors,
+		};
+
+		const component = () => {};
+
+		it( 'should trigger a requirements data update when component requirements change.', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.setState( thing1ClientState );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 30 * SECOND }, 1 );
+			} );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should not trigger a requirements data update when component requirements are still the same.', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.setState( thing1ClientState );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 0 );
+		} );
+
+		it( 'should trigger a requirements data update when the client state is different.', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.setState( thing1ClientState );
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+
+			const thing1new = { name: 'Thing 1 - new' };
+			const thing1ClientState2 = {
+				endpoints: {
+					things: {
+						endpoints: {
+							1: {
+								data: thing1new,
+							},
+						},
+						queries: [
+							{ params: { page: 1, perPage: 3 }, data: [ thing1new ] },
+						],
+					},
+				},
+			};
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setState( thing1ClientState2 );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should not trigger a requirements data update when the client state is still the same.', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.setState( thing1ClientState );
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setState( thing1ClientState );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 0 );
 		} );
 	} );
 } );

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -85,7 +85,7 @@ describe( 'ApiClient', () => {
 		expect( queryData[ 0 ] ).toBe( thing1 );
 	} );
 
-	describe( '#selectComponentData', () => {
+	describe( '#setComponentData', () => {
 		it( 'should select data for component from last state set', () => {
 			const api = {
 				methods: {},
@@ -97,7 +97,7 @@ describe( 'ApiClient', () => {
 			const apiClient = new ApiClient( api, '123' );
 			apiClient.setState( thing1ClientState );
 
-			apiClient.selectComponentData( component, ( selectors ) => {
+			apiClient.setComponentData( component, ( selectors ) => {
 				expect( selectors.getThing( {}, 1 ) ).toBe( thing1 );
 			} );
 		} );
@@ -113,7 +113,7 @@ describe( 'ApiClient', () => {
 			const apiClient = new ApiClient( api, '123' );
 			apiClient.setState( thing1ClientState );
 
-			apiClient.selectComponentData( component, ( selectors ) => {
+			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThing( { freshness: 90 * SECOND }, 1 );
 			} );
 

--- a/src/client/calculate-updates.js
+++ b/src/client/calculate-updates.js
@@ -98,9 +98,10 @@ function appendUpdatesForEndpoint( updateInfo, endpointPath, params, requirement
 		);
 	}
 
+	const isRequested = state.lastRequested > state.lastReceived;
 	const timeoutLeft = getTimeoutLeft( requirements, state, now );
 	const freshnessLeft = getFreshnessLeft( requirements, state, now );
-	const nextUpdate = Math.min( timeoutLeft, freshnessLeft );
+	const nextUpdate = isRequested && 0 >= freshnessLeft ? timeoutLeft : freshnessLeft;
 
 	updateInfo.nextUpdate = Math.min( updateInfo.nextUpdate, nextUpdate );
 	if ( nextUpdate < 0 ) {
@@ -118,8 +119,9 @@ function appendUpdatesForEndpoint( updateInfo, endpointPath, params, requirement
 export function getTimeoutLeft( requirements, state, now ) {
 	const { timeout } = requirements;
 	const { lastRequested } = state;
+	const lastReceived = state.lastReceived || Number.MIN_SAFE_INTEGER;
 
-	if ( timeout && lastRequested ) {
+	if ( timeout && lastRequested && lastRequested > lastReceived ) {
 		return ( lastRequested + timeout ) - now;
 	}
 	return Number.MAX_SAFE_INTEGER;

--- a/src/client/calculate-updates.js
+++ b/src/client/calculate-updates.js
@@ -141,3 +141,4 @@ export function getFreshnessLeft( requirements, state, now ) {
 	}
 	return freshness ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
 }
+

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,5 +1,6 @@
 import debugFactory from 'debug';
-import { calculateClientUpdates, reduceEndpointRequirements } from './requirements';
+import { reduceEndpointRequirements } from './requirements';
+import calculateUpdates from './calculate-updates';
 
 const debug = debugFactory( 'fresh-data:api-client' );
 
@@ -33,7 +34,7 @@ export default class ApiClient {
 	}
 
 	updateRequirements = () => {
-		const updateInfo = calculateClientUpdates( this.clientRequirements, this.state );
+		const updateInfo = calculateUpdates( this.clientRequirements, this.state );
 
 		debug( 'Updating API requirements: ', updateInfo.updates );
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,4 +1,6 @@
 import debugFactory from 'debug';
+import { isEqual } from 'lodash';
+import { combineComponentRequirements } from './requirements';
 import { default as getDataFromState } from './get-data';
 import requireData from './require-data';
 
@@ -18,7 +20,7 @@ export default class ApiClient {
 	setState = ( state ) => {
 		if ( this.state !== state ) {
 			this.state = state;
-			// TODO: Check and update endpoint requirements.
+			this.updateRequirementsData();
 		}
 	}
 
@@ -32,8 +34,22 @@ export default class ApiClient {
 		selectorFunc( selectors );
 
 		this.requirementsByComponent.set( component, componentRequirements );
-		// TODO: Check if the endpoint requirements have changed and update if they have.
+
+		// TODO: Consider using a reducer style function for endpoint requirements so we don't
+		// have to do a deep equals check.
+		const requirementsByEndpoint = combineComponentRequirements( this.requirementsByComponent );
+		if ( ! isEqual( this.requirementsByEndpoint, requirementsByEndpoint ) ) {
+			this.requirementsByEndpoint = requirementsByEndpoint;
+			this.updateRequirementsData();
+		}
 	};
+
+	updateRequirementsData = () => {
+		// TODO: Actually parse the list of requirements against the current state.
+		// TODO: Get a list of requirements that need to be fetched.
+		// TODO: Get the next update time.
+		// TODO: Set/Reset the timer to update.
+	}
 }
 
 function mapMethods( methods, clientKey ) {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -26,16 +26,12 @@ export default class ApiClient {
 		return getData( this.state )( endpointPath, params );
 	};
 
-	selectComponentData = ( component, selectorFunc ) => {
-		let componentRequirements = this.requirementsByComponent.get( component );
-		if ( ! componentRequirements ) {
-			componentRequirements = [];
-			this.requirementsByComponent.set( component, componentRequirements );
-		}
-
+	setComponentData = ( component, selectorFunc ) => {
+		const componentRequirements = [];
 		const selectors = mapSelectors( this.api.selectors, this.getData, requireData( componentRequirements ) );
 		selectorFunc( selectors );
 
+		this.requirementsByComponent.set( component, componentRequirements );
 		// TODO: Check if the endpoint requirements have changed and update if they have.
 	};
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,0 +1,49 @@
+import debugFactory from 'debug';
+import { calculateClientUpdates, reduceEndpointRequirements } from './requirements';
+
+const debug = debugFactory( 'fresh-data:api-client' );
+
+export default class ApiClient {
+	constructor( api, key, state = null, dispatch = null ) {
+		this.api = api;
+		this.key = key;
+		this.clientRequirements = {};
+		this.setState( state, dispatch );
+	}
+
+	setState = ( state, dispatch ) => {
+		this.dispatch = dispatch;
+
+		if ( this.state !== state ) {
+			const { selectors } = this.api;
+			this.state = state;
+			this.selectors = mapSelectorsToState( selectors, state, this.requireData );
+		}
+	}
+
+	// TODO: Add code to clear out data requirements on re-render.
+	requireData = ( endpointName, ids, requirements ) => {
+		const oldEndpointReqs = this.clientRequirements[ endpointName ] || {};
+		const newEndpointReqs = reduceEndpointRequirements( oldEndpointReqs, ids, requirements );
+
+		if ( oldEndpointReqs !== newEndpointReqs ) {
+			this.clientRequirements[ endpointName ] = newEndpointReqs;
+			this.updateRequirements();
+		}
+	}
+
+	updateRequirements = () => {
+		const updateInfo = calculateClientUpdates( this.clientRequirements, this.state );
+
+		debug( 'Updating API requirements: ', updateInfo.updates );
+
+		// TODO: Add code here that calls the API methods and sets the next update.
+	}
+}
+
+function mapSelectorsToState( selectors, state, requireData ) {
+	return Object.keys( selectors ).reduce( ( mappedSelectors, selectorName ) => {
+		mappedSelectors[ selectorName ] = selectors[ selectorName ]( state, requireData );
+		return mappedSelectors;
+	}, {} );
+}

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -5,16 +5,14 @@ import calculateUpdates from './calculate-updates';
 const debug = debugFactory( 'fresh-data:api-client' );
 
 export default class ApiClient {
-	constructor( api, key, state = null, dispatch = null ) {
+	constructor( api, key, state = null ) {
 		this.api = api;
 		this.key = key;
 		this.clientRequirements = {};
-		this.setState( state, dispatch );
+		this.setState( state );
 	}
 
-	setState = ( state, dispatch ) => {
-		this.dispatch = dispatch;
-
+	setState = ( state ) => {
 		if ( this.state !== state ) {
 			const { selectors } = this.api;
 			this.state = state;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,5 +1,5 @@
 import debugFactory from 'debug';
-import getData from './get-data';
+import { default as getDataFromState } from './get-data';
 import requireData from './require-data';
 
 const debug = debugFactory( 'fresh-data:api-client' );
@@ -23,7 +23,7 @@ export default class ApiClient {
 	}
 
 	getData = ( endpointPath, params ) => {
-		return getData( this.state )( endpointPath, params );
+		return getDataFromState( this.state )( endpointPath, params );
 	};
 
 	setComponentData = ( component, selectorFunc ) => {


### PR DESCRIPTION
The ApiClient class represents a given API site indexed by a key.
The key can be platform-dependent. On WordPress.com, for instance,
this would be a numeric siteId. On a normal wp-admin setup, it
would be the API of the site. For a Stripe API, it could be
production or test.

This PR does not do the actual API method calls, however. It leaves that for an upcoming PR.

To Test:
1. `npm test` and ensure all tests pass.