### PR TITLE
Use arrays for component requirement sets.

### DIFF
--- a/src/client/__tests__/calculate-updates.spec.js
+++ b/src/client/__tests__/calculate-updates.spec.js
@@ -105,6 +105,92 @@ describe( 'calculateUpdates', () => {
 		] );
 	} );
 
+	it( 'should not return an update if stale but requested and not yet timed out.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 10 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 121 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [] );
+	} );
+
+	it( 'should return an update if both stale, requested and timed out.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 3 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 121 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [
+			{ endpointPath: [ 'things' ], params: { page: 1, perPage: 3 } },
+		] );
+	} );
+
+	it( 'should not return an update if timed out, but no longer stale.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 3 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 3 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [] );
+	} );
+
 	it( 'should return an empty set if nothing needs an update', () => {
 		const requirementsByEndpoint = {
 			things: {

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -86,14 +86,15 @@ describe( 'ApiClient', () => {
 	} );
 
 	describe( '#setComponentData', () => {
-		it( 'should select data for component from last state set', () => {
-			const api = {
-				methods: {},
-				endpoints: {},
-				selectors: thingSelectors,
-			};
+		const api = {
+			methods: {},
+			endpoints: {},
+			selectors: thingSelectors,
+		};
 
-			const component = () => {};
+		const component = () => {};
+
+		it( 'should select data for component from last state set', () => {
 			const apiClient = new ApiClient( api, '123' );
 			apiClient.setState( thing1ClientState );
 
@@ -103,13 +104,6 @@ describe( 'ApiClient', () => {
 		} );
 
 		it( 'should set requirements for component', () => {
-			const api = {
-				methods: {},
-				endpoints: {},
-				selectors: thingSelectors,
-			};
-
-			const component = () => {};
 			const apiClient = new ApiClient( api, '123' );
 			apiClient.setState( thing1ClientState );
 
@@ -124,6 +118,90 @@ describe( 'ApiClient', () => {
 					endpoint: [ 'things', 1 ],
 				}
 			] );
+		} );
+	} );
+
+	describe( '#updateRequirementsData', () => {
+		const api = {
+			methods: {},
+			endpoints: {},
+			selectors: thingSelectors,
+		};
+
+		const component = () => {};
+
+		it( 'should trigger a requirements data update when component requirements change.', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.setState( thing1ClientState );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 30 * SECOND }, 1 );
+			} );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should not trigger a requirements data update when component requirements are still the same.', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.setState( thing1ClientState );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 0 );
+		} );
+
+		it( 'should trigger a requirements data update when the client state is different.', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.setState( thing1ClientState );
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+
+			const thing1new = { name: 'Thing 1 - new' };
+			const thing1ClientState2 = {
+				endpoints: {
+					things: {
+						endpoints: {
+							1: {
+								data: thing1new,
+							},
+						},
+						queries: [
+							{ params: { page: 1, perPage: 3 }, data: [ thing1new ] },
+						],
+					},
+				},
+			};
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setState( thing1ClientState2 );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should not trigger a requirements data update when the client state is still the same.', () => {
+			const apiClient = new ApiClient( api, '123' );
+			apiClient.setState( thing1ClientState );
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+			} );
+
+			apiClient.updateRequirementsData = jest.fn();
+			apiClient.setState( thing1ClientState );
+			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 0 );
 		} );
 	} );
 } );

--- a/src/client/__tests__/requirements.spec.js
+++ b/src/client/__tests__/requirements.spec.js
@@ -66,6 +66,41 @@ describe( 'addEndpointRequirement', () => {
 		} );
 	} );
 
+	it( 'should add a query requirement with params, a single level deep', () => {
+		const reqs = {};
+		const params = { page: 1, perPage: 10 };
+		addEndpointRequirement( reqs, { freshness: 90 * SECOND }, [ 'thing' ], params );
+		expect( reqs ).toEqual( {
+			thing: {
+				queries: [
+					{
+						params: { page: 1, perPage: 10 },
+						freshness: 90 * SECOND,
+						timeout: DEFAULTS.timeout
+					},
+				],
+			},
+		} );
+	} );
+
+	it( 'should combine a query requirement with an existing one', () => {
+		const reqs = {};
+		const params = { page: 1, perPage: 10 };
+		addEndpointRequirement( reqs, { freshness: 90 * SECOND }, [ 'thing' ], params );
+		addEndpointRequirement( reqs, { freshness: 60 * SECOND }, [ 'thing' ], params );
+		expect( reqs ).toEqual( {
+			thing: {
+				queries: [
+					{
+						params: { page: 1, perPage: 10 },
+						freshness: 60 * SECOND,
+						timeout: DEFAULTS.timeout
+					},
+				],
+			},
+		} );
+	} );
+
 	it( 'should add a requirement two levels deep', () => {
 		const reqs = {};
 		addEndpointRequirement(

--- a/src/client/__tests__/requirements.spec.js
+++ b/src/client/__tests__/requirements.spec.js
@@ -164,7 +164,7 @@ describe( 'combineComponentRequirements', () => {
 	it( 'should return endpoint requirements for a single component.', () => {
 		const reqsByComponent = new Map();
 		const component = () => null;
-		reqsByComponent.set( component, { freshness: 180 * SECOND, endpoint: [ 'thing', 2 ] } );
+		reqsByComponent.set( component, [ { freshness: 180 * SECOND, endpoint: [ 'thing', 2 ] } ] );
 
 		const reqsByEndpoint = combineComponentRequirements( reqsByComponent );
 		expect( reqsByEndpoint ).toEqual( {
@@ -180,8 +180,8 @@ describe( 'combineComponentRequirements', () => {
 		const reqsByComponent = new Map();
 		const component1 = () => null;
 		const component2 = () => null;
-		reqsByComponent.set( component1, { freshness: 60 * SECOND, endpoint: [ 'thing', 1 ] } );
-		reqsByComponent.set( component2, { freshness: 90 * SECOND, endpoint: [ 'thing', 2 ] } );
+		reqsByComponent.set( component1, [ { freshness: 60 * SECOND, endpoint: [ 'thing', 1 ] } ] );
+		reqsByComponent.set( component2, [ { freshness: 90 * SECOND, endpoint: [ 'thing', 2 ] } ] );
 
 		const reqsByEndpoint = combineComponentRequirements( reqsByComponent );
 		expect( reqsByEndpoint ).toEqual( {
@@ -198,14 +198,51 @@ describe( 'combineComponentRequirements', () => {
 		const reqsByComponent = new Map();
 		const component1 = () => null;
 		const component2 = () => null;
-		reqsByComponent.set( component1, { freshness: 30 * SECOND, endpoint: [ 'thing', 2 ] } );
-		reqsByComponent.set( component2, { freshness: 60 * SECOND, timeout: 2 * SECOND, endpoint: [ 'thing', 2 ] } );
+		reqsByComponent.set( component1, [ { freshness: 30 * SECOND, endpoint: [ 'thing', 2 ] } ] );
+		reqsByComponent.set( component2, [ { freshness: 60 * SECOND, timeout: 2 * SECOND, endpoint: [ 'thing', 2 ] } ] );
 
 		const reqsByEndpoint = combineComponentRequirements( reqsByComponent );
 		expect( reqsByEndpoint ).toEqual( {
 			thing: {
 				endpoints: {
 					2: { freshness: 30 * SECOND, timeout: 2 * SECOND },
+				},
+			},
+		} );
+	} );
+
+	it( 'should utilize multiple requirements from one component.', () => {
+		const reqsByComponent = new Map();
+		const component1 = () => null;
+		reqsByComponent.set( component1, [
+			{ freshness: 60 * SECOND, endpoint: [ 'thing', 1 ] },
+			{ freshness: 30 * SECOND, endpoint: [ 'thing', 2 ] },
+		] );
+
+		const reqsByEndpoint = combineComponentRequirements( reqsByComponent );
+		expect( reqsByEndpoint ).toEqual( {
+			thing: {
+				endpoints: {
+					1: { freshness: 60 * SECOND, timeout: DEFAULTS.timeout },
+					2: { freshness: 30 * SECOND, timeout: DEFAULTS.timeout },
+				},
+			},
+		} );
+	} );
+
+	it( 'should collapse redundant requirements from one component.', () => {
+		const reqsByComponent = new Map();
+		const component1 = () => null;
+		reqsByComponent.set( component1, [
+			{ freshness: 60 * SECOND, endpoint: [ 'thing', 1 ] },
+			{ freshness: 30 * SECOND, endpoint: [ 'thing', 1 ] },
+		] );
+
+		const reqsByEndpoint = combineComponentRequirements( reqsByComponent );
+		expect( reqsByEndpoint ).toEqual( {
+			thing: {
+				endpoints: {
+					1: { freshness: 30 * SECOND, timeout: DEFAULTS.timeout },
 				},
 			},
 		} );

--- a/src/client/calculate-updates.js
+++ b/src/client/calculate-updates.js
@@ -98,9 +98,10 @@ function appendUpdatesForEndpoint( updateInfo, endpointPath, params, requirement
 		);
 	}
 
+	const isRequested = state.lastRequested > state.lastReceived;
 	const timeoutLeft = getTimeoutLeft( requirements, state, now );
 	const freshnessLeft = getFreshnessLeft( requirements, state, now );
-	const nextUpdate = Math.min( timeoutLeft, freshnessLeft );
+	const nextUpdate = isRequested && 0 >= freshnessLeft ? timeoutLeft : freshnessLeft;
 
 	updateInfo.nextUpdate = Math.min( updateInfo.nextUpdate, nextUpdate );
 	if ( nextUpdate < 0 ) {
@@ -118,8 +119,9 @@ function appendUpdatesForEndpoint( updateInfo, endpointPath, params, requirement
 export function getTimeoutLeft( requirements, state, now ) {
 	const { timeout } = requirements;
 	const { lastRequested } = state;
+	const lastReceived = state.lastReceived || Number.MIN_SAFE_INTEGER;
 
-	if ( timeout && lastRequested ) {
+	if ( timeout && lastRequested && lastRequested > lastReceived ) {
 		return ( lastRequested + timeout ) - now;
 	}
 	return Number.MAX_SAFE_INTEGER;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,4 +1,6 @@
 import debugFactory from 'debug';
+import { isEqual } from 'lodash';
+import { combineComponentRequirements } from './requirements';
 import { default as getDataFromState } from './get-data';
 import requireData from './require-data';
 
@@ -18,7 +20,7 @@ export default class ApiClient {
 	setState = ( state ) => {
 		if ( this.state !== state ) {
 			this.state = state;
-			// TODO: Check and update endpoint requirements.
+			this.updateRequirementsData();
 		}
 	}
 
@@ -32,8 +34,22 @@ export default class ApiClient {
 		selectorFunc( selectors );
 
 		this.requirementsByComponent.set( component, componentRequirements );
-		// TODO: Check if the endpoint requirements have changed and update if they have.
+
+		// TODO: Consider using a reducer style function for endpoint requirements so we don't
+		// have to do a deep equals check.
+		const requirementsByEndpoint = combineComponentRequirements( this.requirementsByComponent );
+		if ( ! isEqual( this.requirementsByEndpoint, requirementsByEndpoint ) ) {
+			this.requirementsByEndpoint = requirementsByEndpoint;
+			this.updateRequirementsData();
+		}
 	};
+
+	updateRequirementsData = () => {
+		// TODO: Actually parse the list of requirements against the current state.
+		// TODO: Get a list of requirements that need to be fetched.
+		// TODO: Get the next update time.
+		// TODO: Set/Reset the timer to update.
+	}
 }
 
 function mapMethods( methods, clientKey ) {

--- a/src/client/requirements.js
+++ b/src/client/requirements.js
@@ -1,3 +1,4 @@
+import { findIndex } from 'lodash';
 import { SECOND } from '../utils/constants';
 
 export const DEFAULTS = {
@@ -34,9 +35,11 @@ export function addEndpointRequirement( requirementsByEndpoint, reqParams, endpo
 	const [ endpoint, ...remainingPath ] = endpointPath;
 
 	if ( remainingPath.length === 0 ) {
-		const endpointRequirements = requirementsByEndpoint[ endpoint ] || { ...DEFAULTS };
-		addRequirementParams( endpointRequirements, reqParams );
-		requirementsByEndpoint[ endpoint ] = endpointRequirements;
+		if ( params ) {
+			addQueryEndpointRequirementParams( requirementsByEndpoint, reqParams, endpoint, params );
+		} else {
+			addEndpointRequirementParams( requirementsByEndpoint, reqParams, endpoint );
+		}
 	} else {
 		const endpointRequirements = requirementsByEndpoint[ endpoint ] || {};
 		const endpoints = endpointRequirements.endpoints || {};
@@ -45,6 +48,26 @@ export function addEndpointRequirement( requirementsByEndpoint, reqParams, endpo
 		endpointRequirements.endpoints = endpoints;
 		requirementsByEndpoint[ endpoint ] = endpointRequirements;
 	}
+}
+
+function addEndpointRequirementParams( requirementsByEndpoint, reqParams, endpoint ) {
+	const endpointRequirements = requirementsByEndpoint[ endpoint ] || { ...DEFAULTS };
+	addRequirementParams( endpointRequirements, reqParams );
+	requirementsByEndpoint[ endpoint ] = endpointRequirements;
+}
+
+function addQueryEndpointRequirementParams( requirementsByEndpoint, reqParams, endpoint, params ) {
+	const endpointRequirements = requirementsByEndpoint[ endpoint ] || {};
+	const queries = endpointRequirements.queries || [];
+	const queryIndex = findIndex( queries, { params } );
+	const queryRequirements = -1 === queryIndex ? { params, ...DEFAULTS } : queries[ queryIndex ];
+	const newIndex = -1 === queryIndex ? queries.length : queryIndex;
+
+	addRequirementParams( queryRequirements, reqParams );
+
+	queries[ newIndex ] = queryRequirements;
+	endpointRequirements.queries = queries;
+	requirementsByEndpoint[ endpoint ] = endpointRequirements;
 }
 
 /**

--- a/src/client/requirements.js
+++ b/src/client/requirements.js
@@ -11,14 +11,16 @@ export const DEFAULTS = {
  * @return {Object} New requirements endpoint tree.
  */
 export function combineComponentRequirements( requirementsByComponent ) {
-	const requirements = {};
+	const requirementsByEndpoint = {};
 
-	requirementsByComponent.forEach( ( requirement ) => {
-		const { endpoint, params, ...reqParams } = requirement;
-		addEndpointRequirement( requirements, reqParams, endpoint, params );
+	requirementsByComponent.forEach( ( requirements ) => {
+		requirements.forEach( ( requirement ) => {
+			const { endpoint, params, ...reqParams } = requirement;
+			addEndpointRequirement( requirementsByEndpoint, reqParams, endpoint, params );
+		} );
 	} );
 
-	return requirements;
+	return requirementsByEndpoint;
 }
 
 /**


### PR DESCRIPTION
This corrects the component requirement mapping to use an array of
requirements for each component, which is what is expected from the
ApiClient. It adjust existing tests and adds two more to verify
functionality.

To Test:

1. `npm test` and ensure all tests pass.