### PR TITLE
Update/support endpoint query requirements

### DIFF
--- a/src/client/__tests__/calculate-updates.spec.js
+++ b/src/client/__tests__/calculate-updates.spec.js
@@ -105,6 +105,92 @@ describe( 'calculateUpdates', () => {
 		] );
 	} );
 
+	it( 'should not return an update if stale but requested and not yet timed out.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 10 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 121 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [] );
+	} );
+
+	it( 'should return an update if both stale, requested and timed out.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 3 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 121 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [
+			{ endpointPath: [ 'things' ], params: { page: 1, perPage: 3 } },
+		] );
+	} );
+
+	it( 'should not return an update if timed out, but no longer stale.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 3 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 3 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [] );
+	} );
+
 	it( 'should return an empty set if nothing needs an update', () => {
 		const requirementsByEndpoint = {
 			things: {

--- a/src/client/__tests__/requirements.spec.js
+++ b/src/client/__tests__/requirements.spec.js
@@ -66,6 +66,23 @@ describe( 'addEndpointRequirement', () => {
 		} );
 	} );
 
+	it( 'should add a query requirement with params, a single level deep', () => {
+		const reqs = {};
+		const params = { page: 1, perPage: 10 };
+		addEndpointRequirement( reqs, { freshness: 90 * SECOND }, [ 'thing' ], params );
+		expect( reqs ).toEqual( {
+			thing: {
+				queries: [
+					{
+						params: { page: 1, perPage: 10 },
+						freshness: 90 * SECOND,
+						timeout: DEFAULTS.timeout
+					},
+				],
+			},
+		} );
+	} );
+
 	it( 'should add a requirement two levels deep', () => {
 		const reqs = {};
 		addEndpointRequirement(

--- a/src/client/__tests__/requirements.spec.js
+++ b/src/client/__tests__/requirements.spec.js
@@ -83,6 +83,24 @@ describe( 'addEndpointRequirement', () => {
 		} );
 	} );
 
+	it( 'should combine a query requirement with an existing one', () => {
+		const reqs = {};
+		const params = { page: 1, perPage: 10 };
+		addEndpointRequirement( reqs, { freshness: 90 * SECOND }, [ 'thing' ], params );
+		addEndpointRequirement( reqs, { freshness: 60 * SECOND }, [ 'thing' ], params );
+		expect( reqs ).toEqual( {
+			thing: {
+				queries: [
+					{
+						params: { page: 1, perPage: 10 },
+						freshness: 60 * SECOND,
+						timeout: DEFAULTS.timeout
+					},
+				],
+			},
+		} );
+	} );
+
 	it( 'should add a requirement two levels deep', () => {
 		const reqs = {};
 		addEndpointRequirement(

--- a/src/client/calculate-updates.js
+++ b/src/client/calculate-updates.js
@@ -98,9 +98,10 @@ function appendUpdatesForEndpoint( updateInfo, endpointPath, params, requirement
 		);
 	}
 
+	const isRequested = state.lastRequested > state.lastReceived;
 	const timeoutLeft = getTimeoutLeft( requirements, state, now );
 	const freshnessLeft = getFreshnessLeft( requirements, state, now );
-	const nextUpdate = Math.min( timeoutLeft, freshnessLeft );
+	const nextUpdate = isRequested && 0 >= freshnessLeft ? timeoutLeft : freshnessLeft;
 
 	updateInfo.nextUpdate = Math.min( updateInfo.nextUpdate, nextUpdate );
 	if ( nextUpdate < 0 ) {
@@ -118,8 +119,9 @@ function appendUpdatesForEndpoint( updateInfo, endpointPath, params, requirement
 export function getTimeoutLeft( requirements, state, now ) {
 	const { timeout } = requirements;
 	const { lastRequested } = state;
+	const lastReceived = state.lastReceived || Number.MIN_SAFE_INTEGER;
 
-	if ( timeout && lastRequested ) {
+	if ( timeout && lastRequested && lastRequested > lastReceived ) {
 		return ( lastRequested + timeout ) - now;
 	}
 	return Number.MAX_SAFE_INTEGER;

--- a/src/client/requirements.js
+++ b/src/client/requirements.js
@@ -1,3 +1,4 @@
+import { findIndex } from 'lodash';
 import { SECOND } from '../utils/constants';
 
 export const DEFAULTS = {
@@ -34,9 +35,11 @@ export function addEndpointRequirement( requirementsByEndpoint, reqParams, endpo
 	const [ endpoint, ...remainingPath ] = endpointPath;
 
 	if ( remainingPath.length === 0 ) {
-		const endpointRequirements = requirementsByEndpoint[ endpoint ] || { ...DEFAULTS };
-		addRequirementParams( endpointRequirements, reqParams );
-		requirementsByEndpoint[ endpoint ] = endpointRequirements;
+		if ( params ) {
+			addQueryEndpointRequirementParams( requirementsByEndpoint, reqParams, endpoint, params );
+		} else {
+			addEndpointRequirementParams( requirementsByEndpoint, reqParams, endpoint );
+		}
 	} else {
 		const endpointRequirements = requirementsByEndpoint[ endpoint ] || {};
 		const endpoints = endpointRequirements.endpoints || {};
@@ -45,6 +48,26 @@ export function addEndpointRequirement( requirementsByEndpoint, reqParams, endpo
 		endpointRequirements.endpoints = endpoints;
 		requirementsByEndpoint[ endpoint ] = endpointRequirements;
 	}
+}
+
+function addEndpointRequirementParams( requirementsByEndpoint, reqParams, endpoint ) {
+	const endpointRequirements = requirementsByEndpoint[ endpoint ] || { ...DEFAULTS };
+	addRequirementParams( endpointRequirements, reqParams );
+	requirementsByEndpoint[ endpoint ] = endpointRequirements;
+}
+
+function addQueryEndpointRequirementParams( requirementsByEndpoint, reqParams, endpoint, params ) {
+	const endpointRequirements = requirementsByEndpoint[ endpoint ] || {};
+	const queries = endpointRequirements.queries || [];
+	const queryIndex = findIndex( queries, { params } );
+	const queryRequirements = -1 === queryIndex ? { params, ...DEFAULTS } : queries[ queryIndex ];
+	const newIndex = -1 === queryIndex ? queries.length : queryIndex;
+
+	addRequirementParams( queryRequirements, reqParams );
+
+	queries[ newIndex ] = queryRequirements;
+	endpointRequirements.queries = queries;
+	requirementsByEndpoint[ endpoint ] = endpointRequirements;
 }
 
 /**


### PR DESCRIPTION
The query support for converting component requirements to endpoint
requirements was previously missing. This adds that support and a test
to verify it.

To Test:
1. `npm test` and ensure all tests pass.