### PR TITLE
Correct timeout behavior, only when not fresh.

### DIFF
--- a/src/client/__tests__/calculate-updates.spec.js
+++ b/src/client/__tests__/calculate-updates.spec.js
@@ -105,6 +105,92 @@ describe( 'calculateUpdates', () => {
 		] );
 	} );
 
+	it( 'should not return an update if stale but requested and not yet timed out.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 10 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 121 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [] );
+	} );
+
+	it( 'should return an update if both stale, requested and timed out.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 3 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 121 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [
+			{ endpointPath: [ 'things' ], params: { page: 1, perPage: 3 } },
+		] );
+	} );
+
+	it( 'should not return an update if timed out, but no longer stale.', () => {
+		const requirementsByEndpoint = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						freshness: 120 * SECOND,
+						timeout: 3 * SECOND,
+					},
+				],
+			},
+		};
+		const endpointsState = {
+			things: {
+				queries: [
+					{
+						params: { page: 1, perPage: 3 },
+						lastReceived: now - ( 3 * SECOND ),
+						lastRequested: now - ( 5 * SECOND ),
+					},
+				],
+			},
+		};
+
+		const { updates } = calculateUpdates( requirementsByEndpoint, endpointsState, now );
+		expect( updates ).toEqual( [] );
+	} );
+
 	it( 'should return an empty set if nothing needs an update', () => {
 		const requirementsByEndpoint = {
 			things: {

--- a/src/client/calculate-updates.js
+++ b/src/client/calculate-updates.js
@@ -98,9 +98,10 @@ function appendUpdatesForEndpoint( updateInfo, endpointPath, params, requirement
 		);
 	}
 
+	const isRequested = state.lastRequested > state.lastReceived;
 	const timeoutLeft = getTimeoutLeft( requirements, state, now );
 	const freshnessLeft = getFreshnessLeft( requirements, state, now );
-	const nextUpdate = Math.min( timeoutLeft, freshnessLeft );
+	const nextUpdate = isRequested && 0 >= freshnessLeft ? timeoutLeft : freshnessLeft;
 
 	updateInfo.nextUpdate = Math.min( updateInfo.nextUpdate, nextUpdate );
 	if ( nextUpdate < 0 ) {
@@ -118,8 +119,9 @@ function appendUpdatesForEndpoint( updateInfo, endpointPath, params, requirement
 export function getTimeoutLeft( requirements, state, now ) {
 	const { timeout } = requirements;
 	const { lastRequested } = state;
+	const lastReceived = state.lastReceived || Number.MIN_SAFE_INTEGER;
 
-	if ( timeout && lastRequested ) {
+	if ( timeout && lastRequested && lastRequested > lastReceived ) {
 		return ( lastRequested + timeout ) - now;
 	}
 	return Number.MAX_SAFE_INTEGER;


### PR DESCRIPTION
Previously the update code would return a pending update if required
data was timed out, but still fresh. This is incorrect. This code
corrects that oversight and adds tests to verify.

To Test:
1. `npm test` and ensure all tests pass.