### PR TITLE
ApiClient Split out timer from requirement updates

### DIFF
--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -324,8 +324,17 @@ describe( 'ApiClient', () => {
 			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThingPage( { freshness: 90 * SECOND }, 1, 3 );
 			}, now );
+			apiClient.updateRequirementsData( now );
 			expect( apiClient.timeoutId ).toBeGreaterThan( 0 );
+
 			apiClient.setComponentData( component, null );
+			apiClient.updateRequirementsData( now );
+			expect( apiClient.timeoutId ).toBeNull();
+		} );
+
+		it( 'should default endpointsState to empty object.', () => {
+			apiClient.state = {};
+			apiClient.updateRequirementsData( now );
 		} );
 	} );
 

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -1,6 +1,7 @@
 import FreshDataApi from '../../api';
 import ApiClient from '../index';
 import { SECOND } from '../../utils/constants';
+import { DEFAULT_MIN_UPDATE, DEFAULT_MAX_UPDATE } from '../calculate-updates';
 
 describe( 'ApiClient', () => {
 	const now = new Date();
@@ -101,6 +102,11 @@ describe( 'ApiClient', () => {
 		expect( queryData[ 0 ] ).toBe( thing1 );
 	} );
 
+	it( 'should start with no timeoutId', () => {
+		const apiClient = new ApiClient( emptyApi, '123' );
+		expect( apiClient.timeoutId ).toBeNull();
+	} );
+
 	describe( '#setComponentData', () => {
 		class TestApi extends FreshDataApi {
 			static endpoints = {
@@ -161,6 +167,60 @@ describe( 'ApiClient', () => {
 		} );
 	} );
 
+	describe( '#updateTimer', () => {
+		it( 'should accept and use nextUpdate when given.', () => {
+			const setTimer = jest.fn();
+			setTimer.mockReturnValue( 5 ); // return a timeout id.
+			const clearTimer = jest.fn();
+			const apiClient = new ApiClient( emptyApi, '123', setTimer, clearTimer );
+			apiClient.updateTimer( now, 5000 );
+
+			expect( apiClient.timeoutId ).toBe( 5 );
+			expect( setTimer ).toHaveBeenCalledTimes( 1 );
+			expect( setTimer ).toHaveBeenCalledWith( apiClient.updateRequirementsData, 5000 );
+			expect( clearTimer ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should calculate nextUpdate when not given.', () => {
+			const api = {
+				methods: {},
+				endpoints: {},
+				selectors: thingSelectors,
+			};
+			const setTimer = jest.fn();
+			setTimer.mockReturnValue( 5 ); // return a timeout id.
+			const clearTimer = jest.fn();
+			const apiClient = new ApiClient( api, '123', setTimer, clearTimer );
+
+			const component = () => {};
+			apiClient.setComponentData( component, ( selectors ) => {
+				selectors.getThing( { freshness: 60 * SECOND }, 1 );
+			}, now );
+
+			apiClient.updateTimer( now, 5000 );
+
+			expect( apiClient.timeoutId ).toBe( 5 );
+			expect( setTimer ).toHaveBeenCalledTimes( 2 );
+			expect( setTimer ).toHaveBeenCalledWith( apiClient.updateRequirementsData, DEFAULT_MIN_UPDATE );
+			expect( setTimer ).toHaveBeenCalledWith( apiClient.updateRequirementsData, 5000 );
+			expect( clearTimer ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should set timeout to maximum by default.', () => {
+			const setTimer = jest.fn();
+			setTimer.mockReturnValue( 5 ); // return a timeout id.
+			const clearTimer = jest.fn();
+			const apiClient = new ApiClient( emptyApi, '123', setTimer, clearTimer );
+
+			apiClient.updateTimer( now );
+
+			expect( apiClient.timeoutId ).toBe( 5 );
+			expect( setTimer ).toHaveBeenCalledTimes( 1 );
+			expect( setTimer ).toHaveBeenCalledWith( apiClient.updateRequirementsData, DEFAULT_MAX_UPDATE );
+			expect( clearTimer ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	describe( '#updateRequirementsData', () => {
 		class TestApi extends FreshDataApi {
 			static endpoints = {
@@ -183,67 +243,11 @@ describe( 'ApiClient', () => {
 			apiClient.setComponentData( component, null );
 		} );
 
-		it( 'should trigger a requirements data update when component requirements change.', () => {
+		it( 'should not immediately trigger a requirements update when component requirements change.', () => {
 			apiClient.updateRequirementsData = jest.fn();
 			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThing( { freshness: 90 * SECOND }, 1 );
 			} );
-			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
-
-			apiClient.updateRequirementsData = jest.fn();
-			apiClient.setComponentData( component, ( selectors ) => {
-				selectors.getThing( { freshness: 30 * SECOND }, 1 );
-			} );
-			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
-		} );
-
-		it( 'should not trigger a requirements data update when component requirements are still the same.', () => {
-			apiClient.updateRequirementsData = jest.fn();
-			apiClient.setComponentData( component, ( selectors ) => {
-				selectors.getThing( { freshness: 90 * SECOND }, 1 );
-			} );
-			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
-
-			apiClient.updateRequirementsData = jest.fn();
-			apiClient.setComponentData( component, ( selectors ) => {
-				selectors.getThing( { freshness: 90 * SECOND }, 1 );
-			} );
-			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 0 );
-		} );
-
-		it( 'should trigger a requirements data update when the client state is different.', () => {
-			apiClient.setComponentData( component, ( selectors ) => {
-				selectors.getThing( { freshness: 90 * SECOND }, 1 );
-			} );
-
-			const thing1new = { name: 'Thing 1 - new' };
-			const thing1ClientState2 = {
-				endpoints: {
-					things: {
-						endpoints: {
-							1: {
-								data: thing1new,
-							},
-						},
-						queries: [
-							{ params: { page: 1, perPage: 3 }, data: [ thing1new ] },
-						],
-					},
-				},
-			};
-
-			apiClient.updateRequirementsData = jest.fn();
-			apiClient.setState( thing1ClientState2 );
-			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 1 );
-		} );
-
-		it( 'should not trigger a requirements data update when the client state is still the same.', () => {
-			apiClient.setComponentData( component, ( selectors ) => {
-				selectors.getThing( { freshness: 90 * SECOND }, 1 );
-			} );
-
-			apiClient.updateRequirementsData = jest.fn();
-			apiClient.setState( thing1ClientState );
 			expect( apiClient.updateRequirementsData ).toHaveBeenCalledTimes( 0 );
 		} );
 
@@ -252,6 +256,7 @@ describe( 'ApiClient', () => {
 			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThing( { freshness: 90 * SECOND }, 3 );
 			}, now );
+			apiClient.updateRequirementsData( now );
 			expect( apiClient.fetchData ).toHaveBeenCalledWith( [ 'things', '3' ], undefined );
 		} );
 
@@ -260,6 +265,7 @@ describe( 'ApiClient', () => {
 			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThing( { freshness: 90 * SECOND }, 1 );
 			}, now );
+			apiClient.updateRequirementsData( now );
 			expect( apiClient.fetchData ).toHaveBeenCalledWith( [ 'things', '1' ], undefined );
 		} );
 
@@ -268,17 +274,21 @@ describe( 'ApiClient', () => {
 			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThing( { freshness: 95 * SECOND }, 1 );
 			}, now );
+			apiClient.updateRequirementsData( now );
 			expect( apiClient.fetchData ).toHaveBeenCalledTimes( 0 );
 		} );
 
 		it( 'should fetch data when data for an existing requirement goes stale.', () => {
 			apiClient.fetchData = jest.fn();
 			apiClient.setComponentData( component, ( selectors ) => {
-				selectors.getThing( { freshness: 90 * SECOND }, 1 );
+				selectors.getThing( { freshness: 100 * SECOND }, 1 );
 			}, now );
 
-			apiClient.updateRequirementsData( now + ( 20 * SECOND ) );
+			apiClient.updateRequirementsData( now );
+			expect( apiClient.fetchData ).not.toHaveBeenCalled();
 
+			const future = now.getTime() + ( 40 * SECOND );
+			apiClient.updateRequirementsData( future );
 			expect( apiClient.fetchData ).toHaveBeenCalledWith( [ 'things', '1' ], undefined );
 		} );
 
@@ -287,6 +297,8 @@ describe( 'ApiClient', () => {
 			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThingPage( { freshness: 90 * SECOND }, 1, 10 );
 			}, now );
+
+			apiClient.updateRequirementsData( now );
 			expect( apiClient.fetchData ).toHaveBeenCalledWith( [ 'things' ], { page: 1, perPage: 10 } );
 		} );
 
@@ -295,6 +307,8 @@ describe( 'ApiClient', () => {
 			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThingPage( { freshness: 90 * SECOND }, 1, 3 );
 			}, now );
+
+			apiClient.updateRequirementsData( now );
 			expect( apiClient.fetchData ).toHaveBeenCalledTimes( 0 );
 		} );
 
@@ -302,6 +316,7 @@ describe( 'ApiClient', () => {
 			apiClient.setComponentData( component, ( selectors ) => {
 				selectors.getThingPage( { freshness: 90 * SECOND }, 1, 3 );
 			}, now );
+
 			expect( apiClient.timeoutId ).toBeGreaterThan( 0 );
 		} );
 
@@ -376,19 +391,6 @@ describe( 'ApiClient', () => {
 			const apiClient = new ApiClient( api, '123' );
 
 			expect( () => apiClient.fetchData( [ 'things', '1' ] ) ).toThrowError();
-		} );
-	} );
-
-	describe( '#setNextUpdate', () => {
-		it( 'should set and clear timeoutId', () => {
-			const apiClient = new ApiClient( emptyApi, '123' );
-			expect( apiClient.timeoutId ).toBeNull();
-
-			apiClient.setNextUpdate( 5000 );
-			expect( apiClient.timeoutId ).toBeGreaterThan( 0 );
-
-			apiClient.setNextUpdate( null );
-			expect( apiClient.timeoutId ).toBeNull();
 		} );
 	} );
 } );

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -8,7 +8,7 @@ import calculateUpdates, { DEFAULT_MIN_UPDATE, DEFAULT_MAX_UPDATE } from './calc
 const debug = debugFactory( 'fresh-data:api-client' );
 
 export default class ApiClient {
-	constructor( api, key ) {
+	constructor( api, key, setTimer = setTimeout, clearTimer = clearTimeout ) {
 		this.api = api;
 		this.key = key;
 		this.requirementsByComponent = new Map();
@@ -16,15 +16,17 @@ export default class ApiClient {
 		this.methods = mapMethods( api.methods, key );
 		this.minUpdate = DEFAULT_MIN_UPDATE;
 		this.maxUpdate = DEFAULT_MAX_UPDATE;
+		this.setTimer = setTimer;
+		this.clearTimer = clearTimer;
 		this.timeoutId = null;
-		this.setState( {} );
+		this.state = {};
 		debug( 'New ApiClient "' + key + '" for api: ', api );
 	}
 
 	setState = ( state, now = new Date() ) => {
 		if ( this.state !== state ) {
 			this.state = state;
-			this.updateRequirementsData( now );
+			this.updateTimer( now );
 		}
 	}
 
@@ -48,7 +50,7 @@ export default class ApiClient {
 		const requirementsByEndpoint = combineComponentRequirements( this.requirementsByComponent );
 		if ( ! isEqual( this.requirementsByEndpoint, requirementsByEndpoint ) ) {
 			this.requirementsByEndpoint = requirementsByEndpoint;
-			this.updateRequirementsData( now );
+			this.updateTimer( now );
 		}
 	};
 
@@ -66,21 +68,34 @@ export default class ApiClient {
 			} );
 
 			debug( `Scheduling next update for ${ nextUpdate / 1000 } seconds.` );
-			this.setNextUpdate( nextUpdate );
-		} else {
+			this.updateTimer( now, nextUpdate );
+		} else if ( this.timeoutId ) {
 			debug( 'Unscheduling future updates' );
-			this.setNextUpdate( null );
+			this.updateTimer( now, null );
 		}
 	}
 
-	setNextUpdate = ( milliseconds ) => {
+	updateTimer = ( now, nextUpdate = undefined ) => {
+		const { requirementsByEndpoint, state, minUpdate, maxUpdate } = this;
+		const endpointsState = state.endpoints || {};
+
+		if ( undefined === nextUpdate ) {
+			nextUpdate = calculateUpdates(
+				requirementsByEndpoint,
+				endpointsState,
+				minUpdate,
+				maxUpdate,
+				now
+			).nextUpdate;
+		}
+
 		if ( this.timeoutId ) {
-			clearTimeout( this.timeoutId );
+			this.clearTimer( this.timeoutId );
 			this.timeoutId = null;
 		}
 
-		if ( milliseconds ) {
-			this.timeoutId = setTimeout( this.updateRequirementsData, milliseconds );
+		if ( nextUpdate ) {
+			this.timeoutId = this.setTimer( this.updateRequirementsData, nextUpdate );
 		}
 	}
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -54,7 +54,7 @@ export default class ApiClient {
 		}
 	};
 
-	updateRequirementsData = ( now = new Date() ) => {
+	updateRequirementsData = ( now ) => {
 		const { requirementsByEndpoint, state, minUpdate, maxUpdate } = this;
 		const endpointsState = state.endpoints || {};
 


### PR DESCRIPTION
This splits out the timer handling and ensures that all updates happen
through a timeout command instead of ever doing it directly. This helps
ensure that we don't block the main thread for too long and it also
ensures that we will update our state before each re-render.

To Test:
1. `npm test` and ensure all tests pass.