### PR TITLE
with-api-client: Add HOC and test

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,12 @@
 			"\\.(css)$": "identity-obj-proxy"
 		},
 		"setupTestFrameworkScriptFile": "jest-enzyme",
-		"testEnvironment": "enzyme"
+		"testEnvironment": "enzyme",
+		"testPathIgnorePatterns": [
+			"/node_modules/",
+			"/dist/",
+			"/examples/"
+		]
 	},
 	"scripts": {
 		"lint": "eslint .",

--- a/src/react-redux/__tests__/with-api-client.spec.js
+++ b/src/react-redux/__tests__/with-api-client.spec.js
@@ -1,0 +1,61 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import FreshDataApi from '../../api';
+import withApiClient from '../with-api-client';
+
+describe( 'withApiClient', () => {
+	class TestApi extends FreshDataApi {
+	}
+
+	const api = new TestApi();
+
+	const Component = () => {
+		return (
+			<span className="test-span">Testing</span>
+		);
+	};
+	const mapApiToProps = () => ( {} );
+	const getClientKey = () => '123';
+
+	const getApiClient = ( apiName, clientKey ) => {
+		if ( 'test' === apiName ) {
+			return api.getClient( clientKey );
+		}
+	};
+
+	it( 'should render wrapped component.', () => {
+		const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+		const wrapper = mount( <ComponentWithApiClient />, { context: { getApiClient } } );
+		expect( wrapper.find( '.test-span' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'should render wrapped component even without getApiClient in context.', () => {
+		const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+		const wrapper = mount( <ComponentWithApiClient /> );
+		expect( wrapper.find( '.test-span' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'should call getApiClient on mount.', () => {
+		const mockGetApiClient = jest.fn();
+		mockGetApiClient.mockReturnValue( getApiClient( 'test', '123' ) );
+		const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+		mount( <ComponentWithApiClient />, { context: { getApiClient: mockGetApiClient } } );
+
+		expect( mockGetApiClient ).toHaveBeenCalledTimes( 1 );
+		expect( mockGetApiClient ).toHaveBeenCalledWith( 'test', '123' );
+	} );
+
+	describe( '#subscribe', () => {
+	} );
+
+	describe( '#unsubscribe', () => {
+	} );
+
+	describe( '#handleSubscriptionChange', () => {
+	} );
+
+	describe( '#mapApiToProps', () => {
+		it( 'should provide api selectors to mapApiToProps', () => {
+		} );
+	} );
+} );

--- a/src/react-redux/with-api-client.js
+++ b/src/react-redux/with-api-client.js
@@ -1,0 +1,101 @@
+import debugFactory from 'debug';
+import { createElement, Component } from 'react';
+import PropTypes from 'prop-types';
+
+const debug = debugFactory( 'fresh-data:with-api-client' );
+
+export default function withApiClient( apiName, mapApiToProps, getClientKey ) {
+	return function connectWithApiClient( WrappedComponent ) {
+		if ( typeof WrappedComponent !== 'function' ) {
+			debug(
+				'Expected component for function returned by withApiClient',
+				'Instead received ', WrappedComponent
+			);
+		}
+
+		const displayName = WrappedComponent.displayName || WrappedComponent.name || 'component';
+
+		class ApiClientConnect extends Component {
+			static displayName = `ApiClientConnect( ${ displayName } )`;
+			static propTypes = WrappedComponent.propTypes;
+			static contextTypes = {
+				...WrappedComponent.contextTypes,
+				getApiClient: PropTypes.func,
+			};
+			static childContextTypes = WrappedComponent.childContextTypes;
+			static WrappedComponent = WrappedComponent;
+
+			state = { clientKey: null, client: null, clientState: null };
+
+			componentDidMount() {
+				this.updateClient( this.props, this.state );
+			}
+
+			componentDidUpdate( prevProps, prevState ) {
+				if ( this.state.client !== prevState.client && prevState.client ) {
+					prevState.client.unsubscribe( this.handleSubscriptionChange );
+				}
+
+				this.updateClient( this.props, this.state );
+			}
+
+			componentWillUnmount() {
+				this.state.client.unsubscribe( this.handleSubscriptionChange );
+			}
+
+			updateClient = ( nextProps, prevState ) => {
+				const clientKey = getClientKey( nextProps );
+				if ( clientKey !== prevState.clientKey ) {
+					const { getApiClient } = this.context;
+
+					if ( ! getApiClient ) {
+						debug(
+							'getApiClient not found in context. ' +
+							'Ensure this component is a child of the FreshDataProvider component.'
+						);
+						return;
+					}
+
+					const client = getApiClient( apiName, clientKey );
+					client.subscribe( this.handleSubscriptionChange );
+					this.setState( () => {
+						return { clientKey, client };
+					} );
+				}
+			}
+
+			handleSubscriptionChange = ( client ) => {
+				this.setState( ( state ) => {
+					if ( client === state.client ) {
+						// This is our client, set the state.
+						return {
+							clientState: client.state,
+						};
+					}
+				} );
+			}
+
+			render() {
+				const { client } = this.state;
+				let apiProps = {};
+
+				if ( client ) {
+					client.setComponentData(
+						this,
+						( selectors ) => {
+							apiProps = mapApiToProps( selectors, this.props );
+						}
+					);
+				}
+
+				const wrappedProps = {
+					...this.props,
+					...apiProps,
+				};
+				return createElement( WrappedComponent, wrappedProps );
+			}
+		}
+
+		return ApiClientConnect;
+	};
+}

--- a/src/react-redux/with-api-client.js
+++ b/src/react-redux/with-api-client.js
@@ -11,9 +11,10 @@ export default function withApiClient( apiName, mapApiToProps, getClientKey ) {
 				'Expected component for function returned by withApiClient',
 				'Instead received ', WrappedComponent
 			);
+			return null;
 		}
 
-		const displayName = WrappedComponent.displayName || WrappedComponent.name || 'component';
+		const displayName = WrappedComponent.displayName || WrappedComponent.name;
 
 		class ApiClientConnect extends Component {
 			static displayName = `ApiClientConnect( ${ displayName } )`;
@@ -57,9 +58,10 @@ export default function withApiClient( apiName, mapApiToProps, getClientKey ) {
 					}
 
 					const client = getApiClient( apiName, clientKey );
+					const clientState = client.state;
 					client.subscribe( this.handleSubscriptionChange );
 					this.setState( () => {
-						return { clientKey, client };
+						return { clientKey, client, clientState };
 					} );
 				}
 			}

--- a/src/react-redux/with-api-client.js
+++ b/src/react-redux/with-api-client.js
@@ -41,7 +41,9 @@ export default function withApiClient( apiName, mapApiToProps, getClientKey ) {
 			}
 
 			componentWillUnmount() {
-				this.state.client.unsubscribe( this.handleSubscriptionChange );
+				if ( this.state.client ) {
+					this.state.client.unsubscribe( this.handleSubscriptionChange );
+				}
 			}
 
 			updateClient = ( nextProps, prevState ) => {


### PR DESCRIPTION
This adds the `withApiClient` higher order component which works much
like the Redux `connect` HOC. It connects a component to selectors for a
given API.

To Test:
1. `npm test` and ensure all tests pass.