### PR TITLE
examples/wp-rest-api: Add providers

### DIFF
--- a/examples/wp-rest-api/src/App.js
+++ b/examples/wp-rest-api/src/App.js
@@ -1,19 +1,28 @@
 import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { FreshDataProvider } from 'fresh-data';
 import './App.css';
 
-const App = () => {
+const apis = {
+};
+
+const App = ( { store } ) => {
 	return (
-		<div className="App">
-			<header className="App-header">
-				<h1 className="App-title">Fresh Data</h1>
-			</header>
-			<header className="WP-header">
-				<h2><a className="WP-title" href="http://wp-api.org">WordPress REST API</a></h2>
-			</header>
-			<p className="App-intro">
-				TODO: Add components here.
-			</p>
-		</div>
+		<ReduxProvider store={ store } >
+			<FreshDataProvider apis={ apis }>
+				<div className="App">
+					<header className="App-header">
+						<h1 className="App-title">Fresh Data</h1>
+					</header>
+					<header className="WP-header">
+						<h2><a className="WP-title" href="http://wp-api.org">WordPress REST API</a></h2>
+					</header>
+					<p className="App-intro">
+						TODO: Add components here.
+					</p>
+				</div>
+			</FreshDataProvider>
+		</ReduxProvider>
 	);
 };
 

--- a/examples/wp-rest-api/src/create-store.js
+++ b/examples/wp-rest-api/src/create-store.js
@@ -1,0 +1,8 @@
+import { createStore } from 'redux';
+
+export default ( reducer ) => {
+	return createStore(
+		reducer,
+		window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+	);
+};

--- a/examples/wp-rest-api/src/index.js
+++ b/examples/wp-rest-api/src/index.js
@@ -2,5 +2,9 @@ import React from 'react';
 import { render } from 'react-dom';
 import './index.css';
 import App from './App';
+import createStore from './create-store';
+import reducer from './reducer';
 
-render( <App />, document.getElementById( 'root' ) );
+const store = createStore( reducer );
+
+render( <App store={ store } />, document.getElementById( 'root' ) );

--- a/examples/wp-rest-api/src/reducer.js
+++ b/examples/wp-rest-api/src/reducer.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import { reducer as freshData } from 'fresh-data';
+
+const reducers = {
+	freshData,
+};
+
+export default combineReducers( reducers );


### PR DESCRIPTION
This adds the redux and fresh-data providers and reducer to the example
application.

To Test:

1. `npm install`
2. `npm run build`
3. `cd examples/wp-rest-api`
4. `npm install`
5. `npm start`
7. After localhost:3000 comes up in browser, check Redux dev tools state for `freshData: {}`
