### PR TITLE
examples/wp-rest-api: Add application code

### DIFF
--- a/examples/wp-rest-api/src/App.css
+++ b/examples/wp-rest-api/src/App.css
@@ -23,6 +23,34 @@
 	color: white;
 }
 
-.App-intro {
-  font-size: large;
+.site-select {
+	font-size: large;
+	padding: 20px;
+}
+
+.site-select input {
+	font-size: large;
+	padding: 5px;
+	margin: 5px;
+}
+
+.site-select button {
+	font-size: large;
+	padding: 5px;
+	margin: 5px;
+}
+
+.post-list {
+	margin-left: 20%;
+	margin-right: 20%;
+}
+
+.post-date {
+	padding: 5px;
+	text-align: right;
+}
+
+.post-title {
+	padding: 5px;
+	text-align: left;
 }

--- a/examples/wp-rest-api/src/App.js
+++ b/examples/wp-rest-api/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { FreshDataProvider } from 'fresh-data';
-import RecentPosts from './RecentPosts';
+import PostList from './PostList';
 import SiteSelect from './SiteSelect';
 import WpRestApi from './test-wp-rest-api';
 import './App.css';
@@ -22,7 +22,7 @@ const App = ( { store } ) => {
 						<h2><a className="WP-title" href="http://wp-api.org">WordPress REST API</a></h2>
 					</header>
 					<SiteSelect>
-						<RecentPosts />
+						<PostList />
 					</SiteSelect>
 				</div>
 			</FreshDataProvider>

--- a/examples/wp-rest-api/src/App.js
+++ b/examples/wp-rest-api/src/App.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { FreshDataProvider } from 'fresh-data';
+import RecentPosts from './RecentPosts';
+import SiteSelect from './SiteSelect';
+import WpRestApi from './test-wp-rest-api';
 import './App.css';
 
 const apis = {
+	'wp-rest-api': new WpRestApi(),
 };
 
 const App = ( { store } ) => {
@@ -17,9 +21,9 @@ const App = ( { store } ) => {
 					<header className="WP-header">
 						<h2><a className="WP-title" href="http://wp-api.org">WordPress REST API</a></h2>
 					</header>
-					<p className="App-intro">
-						TODO: Add components here.
-					</p>
+					<SiteSelect>
+						<RecentPosts />
+					</SiteSelect>
 				</div>
 			</FreshDataProvider>
 		</ReduxProvider>

--- a/examples/wp-rest-api/src/PostList.js
+++ b/examples/wp-rest-api/src/PostList.js
@@ -17,7 +17,7 @@ function renderPostLine( post ) {
 	);
 }
 
-function RecentPosts( { posts, siteUrl } ) {
+function PostList( { posts, siteUrl } ) {
 	return (
 		<div>
 			<h3>Recent Posts for</h3>
@@ -29,14 +29,14 @@ function RecentPosts( { posts, siteUrl } ) {
 	);
 }
 
-RecentPosts.propTypes = {
+PostList.propTypes = {
 	siteUrl: PropTypes.string,
 	posts: PropTypes.array,
 };
 
 function mapApiToProps( selectors ) {
-	const { getRecentPosts } = selectors;
-	const posts = getRecentPosts( { freshness: 1 * MINUTE, timeout: 3 * SECOND } );
+	const { getPosts } = selectors;
+	const posts = getPosts( { freshness: 5 * MINUTE, timeout: 3 * SECOND } );
 	return {
 		posts,
 	};
@@ -46,4 +46,4 @@ function getClientKey( ownProps ) {
 	return ownProps.siteUrl;
 }
 
-export default withApiClient( 'wp-rest-api', mapApiToProps, getClientKey )( RecentPosts );
+export default withApiClient( 'wp-rest-api', mapApiToProps, getClientKey )( PostList );

--- a/examples/wp-rest-api/src/PostList.js
+++ b/examples/wp-rest-api/src/PostList.js
@@ -9,22 +9,23 @@ function renderPostLine( post ) {
 	const date = new Date( post.date_gmt + 'Z' );
 
 	return (
-		<div className="post_line" key={ post.id }>
-			<a href={ post.link }>{ title }</a>
-			&nbsp;
-			<span className="post_date">({ date.toLocaleString() })</span>
-		</div>
+		<tr className="post-line" key={ post.id }>
+			<td className="post-date">{ date.toLocaleString() }</td>
+			<td className="post-title"><a href={ post.link }>{ title }</a></td>
+		</tr>
 	);
 }
 
 function PostList( { posts, siteUrl } ) {
 	return (
-		<div>
+		<div className="post-list">
 			<h3>Recent Posts for</h3>
 			<h4><pre>{ siteUrl }</pre></h4>
-			<div>
-				{ posts && posts.map( renderPostLine ) }
-			</div>
+			<table>
+				<tbody>
+					{ posts && posts.map( renderPostLine ) }
+				</tbody>
+			</table>
 		</div>
 	);
 }

--- a/examples/wp-rest-api/src/RecentPosts.js
+++ b/examples/wp-rest-api/src/RecentPosts.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MINUTE, SECOND, withApiClient } from 'fresh-data';
+import HtmlToReact from 'html-to-react';
+
+function renderPostLine( post ) {
+	const htmlParser = HtmlToReact.Parser();
+	const title = htmlParser.parse( post.title.rendered );
+	const date = new Date( post.date_gmt + 'Z' );
+
+	return (
+		<div className="post_line" key={ post.id }>
+			<a href={ post.link }>{ title }</a>
+			&nbsp;
+			<span className="post_date">({ date.toLocaleString() })</span>
+		</div>
+	);
+}
+
+function RecentPosts( { posts, siteUrl } ) {
+	return (
+		<div>
+			<h3>Recent Posts for</h3>
+			<h4><pre>{ siteUrl }</pre></h4>
+			<div>
+				{ posts && posts.map( renderPostLine ) }
+			</div>
+		</div>
+	);
+}
+
+RecentPosts.propTypes = {
+	siteUrl: PropTypes.string,
+	posts: PropTypes.array,
+};
+
+function mapApiToProps( selectors ) {
+	const { getRecentPosts } = selectors;
+	const posts = getRecentPosts( { freshness: 1 * MINUTE, timeout: 3 * SECOND } );
+	return {
+		posts,
+	};
+}
+
+function getClientKey( ownProps ) {
+	return ownProps.siteUrl;
+}
+
+export default withApiClient( 'wp-rest-api', mapApiToProps, getClientKey )( RecentPosts );

--- a/examples/wp-rest-api/src/SiteSelect.js
+++ b/examples/wp-rest-api/src/SiteSelect.js
@@ -1,0 +1,94 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { verifySiteUrl } from './test-wp-rest-api';
+
+class SiteSelect extends Component {
+	static propTypes = {
+		children: PropTypes.node.isRequired,
+	};
+
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			url: '',
+			previousSites: [ 'demo.wp-api.org' ],
+		};
+		this.clonedChildren = [];
+	}
+
+	handleChange = ( event ) => {
+		const url = event.target.value.trim();
+		this.setState( () => ( { url, isSiteValid: false } ) );
+	}
+
+	handleSubmit = ( event ) => {
+		this.verifyUrl();
+		event.preventDefault();
+	}
+
+	verifyUrl = () => {
+		const { url, previousSites } = this.state;
+		const siteUrl = url.startsWith( 'http' ) ? url : `http://${ url }`;
+
+		if ( -1 !== previousSites.indexOf( url ) ) {
+			// We've seen this site before, don't verify.
+			this.setState( () => ( {
+				siteUrl,
+				isSiteValid: true,
+			} ) );
+			return;
+		}
+
+		this.setState( () => ( { isVerifyingUrl: true } ) );
+		verifySiteUrl( siteUrl ).then( ( isSiteValid ) => {
+			this.setState( () => ( {
+				siteUrl,
+				isSiteValid,
+				previousSites: [ ...previousSites, url ],
+				isVerifyingUrl: false
+			} ) );
+		} ).catch( ( error ) => {
+			console.error( error ); // eslint-disable-line no-console
+		} );
+	}
+
+	renderChildren() {
+		const { siteUrl } = this.state;
+		const { children } = this.props;
+		return React.Children.map( children, child => React.cloneElement( child, { siteUrl } ) );
+	}
+
+	renderSiteOption( site, index ) {
+		return <option key={ index }>{ site }</option>;
+	}
+
+	// TODO: Render an error state when !isSiteValid.
+	render() {
+		const { url, previousSites, isSiteValid } = this.state;
+
+		return (
+			<div className="site-select">
+				<form onSubmit={ this.handleSubmit }>
+					<label htmlFor="siteSelect">
+						Enter Site URL:
+						<input
+							type="text"
+							id="siteSelect"
+							name="siteSelect"
+							list="previousSites"
+							value={ url }
+							onChange={ this.handleChange }
+						/>
+					</label>
+					<datalist id="previousSites">
+						{ previousSites && previousSites.map( this.renderSiteOption ) }
+					</datalist>
+					<button type="submit">Go!</button>
+				</form>
+				{ isSiteValid && this.renderChildren() }
+			</div>
+		);
+	}
+}
+
+export default SiteSelect;

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -1,0 +1,70 @@
+import { FreshDataApi } from 'fresh-data';
+
+const NAMESPACE = 'wp/v2';
+const API_URL_PREFIX = `wp-json/${ NAMESPACE }`;
+
+export function createApi( fetch = window.fetch ) {
+	class TestWPRestApi extends FreshDataApi {
+		static methods = {
+			get: ( clientKey ) => ( endpointPath ) => ( params ) => { // eslint-disable-line no-unused-vars
+				const baseUrl = `${ clientKey }/${ API_URL_PREFIX }/`;
+				const path = endpointPath.join( '/' );
+				const url = baseUrl + path;
+				return fetch( url ).then( ( response ) => {
+					if ( ! response.ok ) {
+						throw new Error( `HTTP Error for ${ response.url }: ${ response.status }` );
+					}
+
+					return response.json().then( ( data ) => {
+						return data;
+					} );
+				} );
+			},
+		}
+
+		static endpoints = {
+			posts: {
+				read: ( methods, endpointPath, params ) => {
+					const { get } = methods;
+					const fullEndpointPath = [ 'posts', ...endpointPath ];
+					const value = get( fullEndpointPath )( params );
+					return value;
+				},
+			},
+		}
+
+		static selectors = {
+			getRecentPosts: ( getData, requireData ) => ( requirement ) => {
+				const path = [ 'posts' ];
+				requireData( requirement, path );
+				return getData( path ) || [];
+			}
+		}
+	}
+	return TestWPRestApi;
+}
+
+export function verifySiteUrl( siteUrl, fetch = window.fetch ) {
+	const apiUrl = `${ siteUrl }/${ API_URL_PREFIX }`;
+
+	return fetch( apiUrl ).then( ( response ) => {
+		if ( ! response.ok ) {
+			throw new Error( `Invalid Site URL: ${ response.url } Status: ${ response.status }` );
+		}
+
+		return response.json().then( ( data ) => {
+			if ( NAMESPACE !== data.namespace ) {
+				throw new Error( `Expected namespace ${ NAMESPACE } but received ${ data.namespace }` );
+			}
+			const postRoute = `/${ NAMESPACE }/posts`;
+			const posts = data.routes[ postRoute ];
+			if ( ! posts ) {
+				throw new Error( `No route for posts found at ${ postRoute }` );
+			}
+			// It all checks out. We're good to go.
+			return true;
+		} );
+	} );
+}
+
+export default createApi();

--- a/examples/wp-rest-api/src/test-wp-rest-api.js
+++ b/examples/wp-rest-api/src/test-wp-rest-api.js
@@ -1,4 +1,5 @@
 import { FreshDataApi } from 'fresh-data';
+import qs from 'qs';
 
 const NAMESPACE = 'wp/v2';
 const API_URL_PREFIX = `wp-json/${ NAMESPACE }`;
@@ -7,14 +8,15 @@ export function createApi( fetch = window.fetch ) {
 	class TestWPRestApi extends FreshDataApi {
 		static methods = {
 			get: ( clientKey ) => ( endpointPath ) => ( params ) => { // eslint-disable-line no-unused-vars
-				const baseUrl = `${ clientKey }/${ API_URL_PREFIX }/`;
+				const baseUrl = `${ clientKey }/${ API_URL_PREFIX }`;
 				const path = endpointPath.join( '/' );
-				const url = baseUrl + path;
+				const httpParams = { page: params.page, per_page: params.perPage }; // eslint-disable-line camelcase
+				const url = `${ baseUrl }/${ path }${ httpParams ? '?' + qs.stringify( httpParams ) : '' }`;
+
 				return fetch( url ).then( ( response ) => {
 					if ( ! response.ok ) {
 						throw new Error( `HTTP Error for ${ response.url }: ${ response.status }` );
 					}
-
 					return response.json().then( ( data ) => {
 						return data;
 					} );
@@ -34,10 +36,11 @@ export function createApi( fetch = window.fetch ) {
 		}
 
 		static selectors = {
-			getRecentPosts: ( getData, requireData ) => ( requirement ) => {
+			getPosts: ( getData, requireData ) => ( requirement, page = 1, perPage = 10 ) => {
 				const path = [ 'posts' ];
-				requireData( requirement, path );
-				return getData( path ) || [];
+				const params = { page, perPage };
+				requireData( requirement, path, params );
+				return getData( path, params ) || [];
 			}
 		}
 	}


### PR DESCRIPTION
This adds an application that looks up recent posts, in addition to
implementing at test api class for the WordPress REST API

To Test:
1. `npm install`
2. `npm run build`
3. `cd examples/wp-rest-api`
4. `npm install`
5. `npm start`
6. Browser will open to localhost:3000
7. Type in URL of any WordPress site with API running and hit <enter> or "Go!" button.
8. Observe page of posts listing in a table.

This example app is functional at this point, but could be improved. Some things I'm considering:

1. Removing the `Go!` button and just automatically trying the URL after the user stops typing.
2. Adding a "Checking http://myurl.com" label while it's verifying the URL goes to a WordPress site.
3. Adding page links and a per-page selector.

Known issue:
There's a promise timing out and throwing in the console. I think this is an actual issue in the fresh-data module. It doesn't affect the behavior of this application.