### PR TITLE
Update examples package.json and lockfiles

### DIFF
--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -3867,27 +3867,11131 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fresh-data": {
-      "version": "github:coderkevin/fresh-data#25bc6a40a142570f7b402bd4d14225e3a18cedc9",
-      "from": "github:coderkevin/fresh-data",
+      "version": "file:../..",
       "requires": {
-        "debug": "^3.1.0",
-        "lodash": "^4.17.10",
-        "react": "^16.4.0",
-        "react-dom": "^16.4.0"
+        "prop-types": "^15.6.1"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.42",
+          "bundled": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.42"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.44",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.44",
+            "@babel/template": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.44"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.44"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.42",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44",
+            "babylon": "7.0.0-beta.44",
+            "lodash": "^4.2.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "7.0.0-beta.44"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.44",
+            "@babel/generator": "7.0.0-beta.44",
+            "@babel/helper-function-name": "7.0.0-beta.44",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44",
+            "babylon": "7.0.0-beta.44",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "7.0.0-beta.44"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
+              }
+            },
+            "globals": {
+              "version": "11.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^2.0.0"
+          },
+          "dependencies": {
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "@mrmlnc/readdir-enhanced": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "glob-to-regexp": "^0.3.0"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "@samverschueren/stream-to-observable": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "any-observable": "^0.3.0"
+          }
+        },
+        "@sindresorhus/is": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "@types/estree": {
+          "version": "0.0.39",
+          "bundled": true
+        },
+        "@types/node": {
+          "version": "10.1.4",
+          "bundled": true
+        },
+        "@webassemblyjs/ast": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/wast-parser": "1.4.3",
+            "debug": "^3.1.0",
+            "webassemblyjs": "1.4.3"
+          }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-buffer": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "debug": "^3.1.0"
+          }
+        },
+        "@webassemblyjs/helper-code-frame": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/wast-printer": "1.4.3"
+          }
+        },
+        "@webassemblyjs/helper-fsm": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-buffer": "1.4.3",
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/wasm-gen": "1.4.3",
+            "debug": "^3.1.0"
+          }
+        },
+        "@webassemblyjs/leb128": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "leb": "^0.3.0"
+          }
+        },
+        "@webassemblyjs/validation": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3"
+          }
+        },
+        "@webassemblyjs/wasm-edit": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-buffer": "1.4.3",
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/helper-wasm-section": "1.4.3",
+            "@webassemblyjs/wasm-gen": "1.4.3",
+            "@webassemblyjs/wasm-opt": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "@webassemblyjs/wast-printer": "1.4.3",
+            "debug": "^3.1.0"
+          }
+        },
+        "@webassemblyjs/wasm-gen": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/leb128": "1.4.3"
+          }
+        },
+        "@webassemblyjs/wasm-opt": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-buffer": "1.4.3",
+            "@webassemblyjs/wasm-gen": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "debug": "^3.1.0"
+          }
+        },
+        "@webassemblyjs/wasm-parser": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/leb128": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "webassemblyjs": "1.4.3"
+          }
+        },
+        "@webassemblyjs/wast-parser": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/floating-point-hex-parser": "1.4.3",
+            "@webassemblyjs/helper-code-frame": "1.4.3",
+            "@webassemblyjs/helper-fsm": "1.4.3",
+            "long": "^3.2.0",
+            "webassemblyjs": "1.4.3"
+          }
+        },
+        "@webassemblyjs/wast-printer": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/wast-parser": "1.4.3",
+            "long": "^3.2.0"
+          }
+        },
+        "abab": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "accepts": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "mime-types": "~2.1.18",
+            "negotiator": "0.6.1"
+          }
+        },
+        "acorn": {
+          "version": "5.5.3",
+          "bundled": true
+        },
+        "acorn-dynamic-import": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.0.0"
+          }
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.0.0"
+          }
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "6.5.0",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "uri-js": "^4.2.1"
+          },
+          "dependencies": {
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansi-html": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "any-observable": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "default-require-extensions": "^1.0.0"
+          }
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "argv": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "aria-query": {
+          "version": "0.7.1",
+          "bundled": true,
+          "requires": {
+            "ast-types-flow": "0.0.7",
+            "commander": "^2.11.0"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "array-differ": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "array-flatten": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "array-includes": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.7.0"
+          }
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "asn1.js": {
+          "version": "4.10.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "assert": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "util": "0.10.3"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ast-types": {
+          "version": "0.11.3",
+          "bundled": true
+        },
+        "ast-types-flow": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "astral-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "atob": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "axobject-query": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "ast-types-flow": "0.0.7"
+          }
+        },
+        "babel-cli": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "chokidar": "^1.6.1",
+            "commander": "^2.11.0",
+            "convert-source-map": "^1.5.0",
+            "fs-readdir-recursive": "^1.0.0",
+            "glob": "^7.1.2",
+            "lodash": "^4.17.4",
+            "output-file-sync": "^1.1.2",
+            "path-is-absolute": "^1.0.1",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.6",
+            "v8flags": "^2.1.1"
+          },
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
+              }
+            },
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "chokidar": {
+              "version": "1.7.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-glob": "^2.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            }
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-core": {
+          "version": "6.26.3",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.1",
+            "debug": "^2.6.9",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.8",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.7"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "babel-eslint": {
+          "version": "8.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.44",
+            "@babel/traverse": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44",
+            "babylon": "7.0.0-beta.44",
+            "eslint-scope": "~3.7.1",
+            "eslint-visitor-keys": "^1.0.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "7.0.0-beta.44"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
+              }
+            }
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-helper-bindify-decorators": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-assignable-expression": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-builder-react-jsx": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "esutils": "^2.0.2"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-define-map": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-explode-class": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-bindify-decorators": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-jest": {
+          "version": "23.0.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-istanbul": "^4.1.6",
+            "babel-preset-jest": "^23.0.1"
+          }
+        },
+        "babel-loader": {
+          "version": "7.1.4",
+          "bundled": true,
+          "requires": {
+            "find-cache-dir": "^1.0.0",
+            "loader-utils": "^1.0.2",
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-external-helpers": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "4.1.6",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+            "find-up": "^2.1.0",
+            "istanbul-lib-instrument": "^1.10.1",
+            "test-exclude": "^4.2.1"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "23.0.1",
+          "bundled": true
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-async-generators": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-class-constructor-call": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-class-properties": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-decorators": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-dynamic-import": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-export-extensions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-flow": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-async-generator-functions": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-generators": "^6.5.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-class-constructor-call": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-class-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-plugin-syntax-class-properties": "^6.8.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-decorators": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-class": "^6.24.1",
+            "babel-plugin-syntax-decorators": "^6.13.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-define-map": "^6.24.1",
+            "babel-helper-function-name": "^6.24.1",
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.26.2",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-types": "^6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-call-delegate": "^6.24.1",
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "regexpu-core": "^2.0.0"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-export-extensions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-export-extensions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-flow-strip-types": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-flow": "^6.18.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-object-rest-spread": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+            "babel-runtime": "^6.26.0"
+          }
+        },
+        "babel-plugin-transform-react-display-name": {
+          "version": "6.25.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-react-jsx": "^6.24.1",
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-self": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-source": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "regenerator-transform": "^0.10.0"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-polyfill": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "regenerator-runtime": "^0.10.5"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "bundled": true
+            }
+          }
+        },
+        "babel-preset-env": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "^6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+            "babel-plugin-transform-async-to-generator": "^6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+            "babel-plugin-transform-es2015-classes": "^6.23.0",
+            "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+            "babel-plugin-transform-es2015-for-of": "^6.23.0",
+            "babel-plugin-transform-es2015-function-name": "^6.22.0",
+            "babel-plugin-transform-es2015-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+            "babel-plugin-transform-es2015-object-super": "^6.22.0",
+            "babel-plugin-transform-es2015-parameters": "^6.23.0",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-spread": "^6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+            "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+            "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+            "babel-plugin-transform-regenerator": "^6.22.0",
+            "browserslist": "^3.2.6",
+            "invariant": "^2.2.2",
+            "semver": "^5.3.0"
+          }
+        },
+        "babel-preset-es2015": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "^6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+            "babel-plugin-transform-es2015-classes": "^6.24.1",
+            "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+            "babel-plugin-transform-es2015-for-of": "^6.22.0",
+            "babel-plugin-transform-es2015-function-name": "^6.24.1",
+            "babel-plugin-transform-es2015-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+            "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+            "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+            "babel-plugin-transform-es2015-object-super": "^6.24.1",
+            "babel-plugin-transform-es2015-parameters": "^6.24.1",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+            "babel-plugin-transform-es2015-spread": "^6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+            "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+            "babel-plugin-transform-regenerator": "^6.24.1"
+          }
+        },
+        "babel-preset-flow": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-flow-strip-types": "^6.22.0"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "23.0.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "^23.0.1",
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+          }
+        },
+        "babel-preset-react": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.3.13",
+            "babel-plugin-transform-react-display-name": "^6.23.0",
+            "babel-plugin-transform-react-jsx": "^6.24.1",
+            "babel-plugin-transform-react-jsx-self": "^6.22.0",
+            "babel-plugin-transform-react-jsx-source": "^6.22.0",
+            "babel-preset-flow": "^6.23.0"
+          }
+        },
+        "babel-preset-stage-1": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-class-constructor-call": "^6.24.1",
+            "babel-plugin-transform-export-extensions": "^6.22.0",
+            "babel-preset-stage-2": "^6.24.1"
+          }
+        },
+        "babel-preset-stage-2": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-dynamic-import": "^6.18.0",
+            "babel-plugin-transform-class-properties": "^6.24.1",
+            "babel-plugin-transform-decorators": "^6.24.1",
+            "babel-preset-stage-3": "^6.24.1"
+          }
+        },
+        "babel-preset-stage-3": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+            "babel-plugin-transform-async-generator-functions": "^6.24.1",
+            "babel-plugin-transform-async-to-generator": "^6.24.1",
+            "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+            "babel-plugin-transform-object-rest-spread": "^6.22.0"
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            }
+          }
+        },
+        "base64-js": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "batch": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "big.js": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "binary-extensions": {
+          "version": "1.11.0",
+          "bundled": true
+        },
+        "binaryextensions": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "bundled": true
+        },
+        "body-parser": {
+          "version": "1.18.2",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "~1.6.15"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "bonjour": {
+          "version": "3.5.0",
+          "bundled": true,
+          "requires": {
+            "array-flatten": "^2.1.0",
+            "deep-equal": "^1.0.1",
+            "dns-equal": "^1.0.0",
+            "dns-txt": "^2.0.2",
+            "multicast-dns": "^6.0.1",
+            "multicast-dns-service-types": "^1.1.0"
+          }
+        },
+        "boolbase": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "kind-of": "^6.0.2",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "brorand": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "browser-process-hrtime": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "browser-resolve": {
+          "version": "1.11.2",
+          "bundled": true,
+          "requires": {
+            "resolve": "1.1.7"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.7",
+              "bundled": true
+            }
+          }
+        },
+        "browserify-aes": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "browserify-cipher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
+          }
+        },
+        "browserify-des": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "browserify-rsa": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "browserify-sign": {
+          "version": "4.0.4",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.1",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.2",
+            "elliptic": "^6.0.0",
+            "inherits": "^2.0.1",
+            "parse-asn1": "^5.0.0"
+          }
+        },
+        "browserify-zlib": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "pako": "~1.0.5"
+          }
+        },
+        "browserslist": {
+          "version": "3.2.8",
+          "bundled": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
+          }
+        },
+        "bser": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "node-int64": "^0.4.0"
+          }
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "bundled": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "buffer-from": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "buffer-indexof": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "buffer-xor": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtin-status-codes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "cacache": {
+          "version": "10.0.4",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.1",
+            "mississippi": "^2.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^5.2.4",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "cacheable-request": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "clone-response": "1.0.2",
+            "get-stream": "3.0.0",
+            "http-cache-semantics": "3.8.1",
+            "keyv": "3.0.0",
+            "lowercase-keys": "1.0.0",
+            "normalize-url": "2.0.1",
+            "responselike": "1.0.2"
+          },
+          "dependencies": {
+            "lowercase-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "call-me-maybe": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          },
+          "dependencies": {
+            "callsites": {
+              "version": "0.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "callsites": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000846",
+          "bundled": true
+        },
+        "capture-exit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "rsvp": "^3.3.3"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "cheerio": {
+          "version": "1.0.0-rc.2",
+          "bundled": true,
+          "requires": {
+            "css-select": "~1.2.0",
+            "dom-serializer": "~0.1.0",
+            "entities": "~1.1.1",
+            "htmlparser2": "^3.9.1",
+            "lodash": "^4.15.0",
+            "parse5": "^3.0.1"
+          },
+          "dependencies": {
+            "parse5": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "@types/node": "*"
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.0"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "chrome-trace-event": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "ci-info": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "cipher-base": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "bundled": true
+        },
+        "circular-json-es6": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-spinners": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "cli-table": {
+          "version": "0.3.1",
+          "bundled": true,
+          "requires": {
+            "colors": "1.0.3"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "cli-truncate": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "slice-ansi": "0.0.4",
+            "string-width": "^1.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "clone-buffer": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "clone-response": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "cloneable-readable": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "process-nextick-args": "^2.0.0",
+            "readable-stream": "^2.3.5"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "codecov": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "argv": "0.0.2",
+            "request": "^2.81.0",
+            "urlgrey": "0.4.4"
+          }
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "^1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.13.0",
+          "bundled": true
+        },
+        "comment-parser": {
+          "version": "0.4.2",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.0.4"
+          }
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "compare-versions": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "compressible": {
+          "version": "2.0.13",
+          "bundled": true,
+          "requires": {
+            "mime-db": ">= 1.33.0 < 2"
+          }
+        },
+        "compression": {
+          "version": "1.7.2",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "bytes": "3.0.0",
+            "compressible": "~2.0.13",
+            "debug": "2.6.9",
+            "on-headers": "~1.0.1",
+            "safe-buffer": "5.1.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "connect-history-api-fallback": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "date-now": "^0.1.4"
+          }
+        },
+        "constants-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
+          }
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "create-ecdh": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.0.0"
+          }
+        },
+        "create-hash": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
+          }
+        },
+        "create-hmac": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "cross-env": {
+          "version": "5.1.6",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^5.1.0",
+            "is-windows": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
+          }
+        },
+        "css-select": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+          }
+        },
+        "css-what": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "0.3.1",
+          "bundled": true,
+          "requires": {
+            "cssom": "0.3.x"
+          }
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "array-find-index": "^1.0.1"
+          }
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "d": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "es5-ext": "^0.10.9"
+          }
+        },
+        "damerau-levenshtein": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "dargs": {
+          "version": "5.1.0",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "data-urls": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "abab": "^1.0.4",
+            "whatwg-mimetype": "^2.0.0",
+            "whatwg-url": "^6.4.0"
+          }
+        },
+        "date-fns": {
+          "version": "1.29.0",
+          "bundled": true
+        },
+        "date-now": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "dateformat": {
+          "version": "3.0.3",
+          "bundled": true
+        },
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "bundled": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-equal-ident": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash.isequal": "^3.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "foreach": "^2.0.5",
+            "object-keys": "^1.0.8"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          }
+        },
+        "del": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "globby": {
+              "version": "6.1.0",
+              "bundled": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "depd": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "des.js": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "detect-conflict": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "detect-node": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "diff": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "diffie-hellman": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
+          }
+        },
+        "dir-glob": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "path-type": "^3.0.0"
+          },
+          "dependencies": {
+            "path-type": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            }
+          }
+        },
+        "discontinuous-range": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "dns-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "dns-packet": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "ip": "^1.1.0",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "dns-txt": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "buffer-indexof": "^1.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "dom-serializer": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "~1.1.1",
+            "entities": "~1.1.1"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.1.3",
+              "bundled": true
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "domelementtype": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "domexception": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "domhandler": {
+          "version": "2.4.2",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "duplexify": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
+        },
+        "editions": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ejs": {
+          "version": "2.6.1",
+          "bundled": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.48",
+          "bundled": true
+        },
+        "elegant-spinner": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "elliptic": {
+          "version": "6.4.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "6.5.1",
+          "bundled": true
+        },
+        "emojis-list": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "encodeurl": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.4.0",
+            "tapable": "^1.0.0"
+          }
+        },
+        "entities": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "envinfo": {
+          "version": "5.8.1",
+          "bundled": true
+        },
+        "enzyme": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "cheerio": "^1.0.0-rc.2",
+            "function.prototype.name": "^1.0.3",
+            "has": "^1.0.1",
+            "is-boolean-object": "^1.0.0",
+            "is-callable": "^1.1.3",
+            "is-number-object": "^1.0.3",
+            "is-string": "^1.0.4",
+            "is-subset": "^0.1.1",
+            "lodash": "^4.17.4",
+            "object-inspect": "^1.5.0",
+            "object-is": "^1.0.1",
+            "object.assign": "^4.1.0",
+            "object.entries": "^1.0.4",
+            "object.values": "^1.0.4",
+            "raf": "^3.4.0",
+            "rst-selector-parser": "^2.2.3"
+          }
+        },
+        "enzyme-adapter-react-16": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "enzyme-adapter-utils": "^1.3.0",
+            "lodash": "^4.17.4",
+            "object.assign": "^4.0.4",
+            "object.values": "^1.0.4",
+            "prop-types": "^15.6.0",
+            "react-reconciler": "^0.7.0",
+            "react-test-renderer": "^16.0.0-0"
+          }
+        },
+        "enzyme-adapter-utils": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.4",
+            "object.assign": "^4.0.4",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "enzyme-matchers": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "circular-json-es6": "^2.0.1",
+            "deep-equal-ident": "^1.1.1"
+          }
+        },
+        "enzyme-to-json": {
+          "version": "3.3.4",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.4"
+          }
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "prr": "~1.0.1"
+          }
+        },
+        "error": {
+          "version": "7.0.2",
+          "bundled": true,
+          "requires": {
+            "string-template": "~0.2.1",
+            "xtend": "~4.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.1",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.1"
+          }
+        },
+        "es5-ext": {
+          "version": "0.10.42",
+          "bundled": true,
+          "requires": {
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.1",
+            "next-tick": "1"
+          }
+        },
+        "es6-iterator": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "^0.10.35",
+            "es6-symbol": "^3.1.1"
+          }
+        },
+        "es6-symbol": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "escodegen": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "3.1.3",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "eslint": {
+          "version": "4.19.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.4",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.0.1",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "globals": {
+              "version": "11.4.0",
+              "bundled": true
+            },
+            "inquirer": {
+              "version": "3.3.0",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "eslint-config-wordpress": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "eslint-plugin-i18n": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "eslint-plugin-jest": {
+          "version": "21.15.2",
+          "bundled": true
+        },
+        "eslint-plugin-jsdoc": {
+          "version": "3.5.0",
+          "bundled": true,
+          "requires": {
+            "comment-parser": "^0.4.2",
+            "lodash": "^4.17.4"
+          }
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "6.0.3",
+          "bundled": true,
+          "requires": {
+            "aria-query": "^0.7.0",
+            "array-includes": "^3.0.3",
+            "ast-types-flow": "0.0.7",
+            "axobject-query": "^0.1.0",
+            "damerau-levenshtein": "^1.0.0",
+            "emoji-regex": "^6.1.0",
+            "jsx-ast-utils": "^2.0.0"
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "ignore": "^3.3.6",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.3.3",
+            "semver": "^5.4.1"
+          }
+        },
+        "eslint-plugin-react": {
+          "version": "7.8.2",
+          "bundled": true,
+          "requires": {
+            "doctrine": "^2.0.2",
+            "has": "^1.0.1",
+            "jsx-ast-utils": "^2.0.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "eslint-plugin-wordpress": {
+          "version": "0.1.0",
+          "from": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git",
+          "bundled": true,
+          "requires": {
+            "eslint-plugin-i18n": "~1.2.0",
+            "eslint-plugin-jsdoc": "~3.5.0",
+            "eslint-plugin-node": "~6.0.1",
+            "eslint-plugin-wpcalypso": "~4.0.1",
+            "merge": "~1.2.0"
+          }
+        },
+        "eslint-plugin-wpcalypso": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "requireindex": "^1.1.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.1",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "espree": {
+          "version": "3.5.4",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "esquery": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "estree-walker": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "bundled": true
+        },
+        "eventemitter3": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "events": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "eventsource": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "original": ">=0.0.5"
+          }
+        },
+        "evp_bytestokey": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "exec-sh": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "merge": "^1.1.3"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "requires": {
+            "fill-range": "^2.1.0"
+          },
+          "dependencies": {
+            "fill-range": {
+              "version": "2.2.3",
+              "bundled": true,
+              "requires": {
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
+              }
+            },
+            "is-number": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "isobject": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "expand-tilde": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
+        "expect": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "jest-diff": "^22.4.3",
+            "jest-get-type": "^22.4.3",
+            "jest-matcher-utils": "^22.4.3",
+            "jest-message-util": "^22.4.3",
+            "jest-regex-util": "^22.4.3"
+          }
+        },
+        "express": {
+          "version": "4.16.3",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.5",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
+            "content-type": "~1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "1.1.1",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~2.0.3",
+            "qs": "6.5.1",
+            "range-parser": "~1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.2",
+            "serve-static": "1.13.2",
+            "setprototypeof": "1.1.0",
+            "statuses": "~1.4.0",
+            "type-is": "~1.6.16",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "array-flatten": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "external-editor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fast-glob": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.0.1",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.1",
+            "micromatch": "^3.1.10"
+          },
+          "dependencies": {
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            }
+          }
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "faye-websocket": {
+          "version": "0.10.0",
+          "bundled": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        },
+        "fb-watchman": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "bser": "^2.0.0"
+          }
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "bundled": true,
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.9"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "bundled": true
+            }
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fileset": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.3",
+            "minimatch": "^3.0.3"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "finalhandler": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.4.0",
+            "unpipe": "~1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "first-chunk-stream": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "circular-json": "^0.3.1",
+            "del": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "write": "^0.2.1"
+          },
+          "dependencies": {
+            "del": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
+              }
+            },
+            "globby": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "flow-parser": {
+          "version": "0.73.0",
+          "bundled": true
+        },
+        "flush-write-stream": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^3.1.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.1"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fsevents": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.5.1",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.21",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.2.4",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "function.prototype.name": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "is-callable": "^1.1.3"
+          }
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "gh-got": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "got": "^7.0.0",
+            "is-plain-obj": "^1.1.0"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            },
+            "p-cancelable": {
+              "version": "0.3.0",
+              "bundled": true
+            },
+            "p-timeout": {
+              "version": "1.2.1",
+              "bundled": true,
+              "requires": {
+                "p-finally": "^1.0.0"
+              }
+            },
+            "prepend-http": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "url-parse-lax": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "prepend-http": "^1.0.1"
+              }
+            }
+          }
+        },
+        "github-username": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "gh-got": "^6.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-all": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5",
+            "yargs": "~1.2.6"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "1.2.6",
+              "bundled": true,
+              "requires": {
+                "minimist": "^0.1.0"
+              }
+            }
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          },
+          "dependencies": {
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "^2.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "global-modules": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "8.0.1",
+          "bundled": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "got": {
+          "version": "8.3.1",
+          "bundled": true,
+          "requires": {
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "grouped-queue": {
+          "version": "0.3.3",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.2"
+          }
+        },
+        "growly": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "handle-thing": {
+          "version": "1.2.5",
+          "bundled": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.7",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            }
+          }
+        },
+        "harmony-reflect": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "has": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.0.2"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-color": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbol-support-x": {
+          "version": "1.4.2",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-to-string-tag-x": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "has-symbol-support-x": "^1.4.1"
+          }
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "hash-base": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "hmac-drbg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.0",
+          "bundled": true
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.1"
+          }
+        },
+        "homedir-polyfill": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "parse-passwd": "^1.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true
+        },
+        "hpack.js": {
+          "version": "2.1.6",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "obuf": "^1.0.0",
+            "readable-stream": "^2.0.1",
+            "wbuf": "^1.1.0"
+          }
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "whatwg-encoding": "^1.0.1"
+          }
+        },
+        "html-entities": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "bundled": true
+        },
+        "http-deceiver": {
+          "version": "1.2.7",
+          "bundled": true
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "bundled": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "http-parser-js": {
+          "version": "0.4.13",
+          "bundled": true
+        },
+        "http-proxy": {
+          "version": "1.17.0",
+          "bundled": true,
+          "requires": {
+            "eventemitter3": "^3.0.0",
+            "follow-redirects": "^1.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "0.18.0",
+          "bundled": true,
+          "requires": {
+            "http-proxy": "^1.16.2",
+            "is-glob": "^4.0.0",
+            "lodash": "^4.17.5",
+            "micromatch": "^3.1.9"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "identity-obj-proxy": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "harmony-reflect": "^1.4.6"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.11",
+          "bundled": true
+        },
+        "iferr": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "3.3.7",
+          "bundled": true
+        },
+        "import-local": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "pkg-dir": "^2.0.0",
+            "resolve-cwd": "^2.0.0"
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "internal-ip": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "meow": "^3.3.0"
+          }
+        },
+        "interpret": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "into-stream": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "from2": "^2.1.1",
+            "p-is-promise": "^1.1.0"
+          }
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "ipaddr.js": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-boolean-object": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "is-ci": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ci-info": "^1.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-generator-fn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-module": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-number-object": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-observable": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "^1.1.0"
+          },
+          "dependencies": {
+            "symbol-observable": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-odd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-scoped": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "scoped-regex": "^1.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-string": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "is-subset": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-wsl": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isbinaryfile": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "istanbul-api": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "async": "^2.1.4",
+            "compare-versions": "^3.1.0",
+            "fileset": "^2.0.2",
+            "istanbul-lib-coverage": "^1.2.0",
+            "istanbul-lib-hook": "^1.2.0",
+            "istanbul-lib-instrument": "^1.10.1",
+            "istanbul-lib-report": "^1.1.4",
+            "istanbul-lib-source-maps": "^1.2.4",
+            "istanbul-reports": "^1.3.0",
+            "js-yaml": "^3.7.0",
+            "mkdirp": "^0.5.1",
+            "once": "^1.4.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "^4.17.10"
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "1.2.4",
+              "bundled": true,
+              "requires": {
+                "debug": "^3.1.0",
+                "istanbul-lib-coverage": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.1",
+                "source-map": "^0.5.3"
+              }
+            },
+            "lodash": {
+              "version": "4.17.10",
+              "bundled": true
+            }
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "append-transform": "^0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.10.1",
+          "bundled": true,
+          "requires": {
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "semver": "^5.3.0"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            }
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "istanbul-lib-coverage": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.3",
+          "bundled": true,
+          "requires": {
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "handlebars": "^4.0.3"
+          }
+        },
+        "istextorbinary": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "binaryextensions": "2",
+            "editions": "^1.3.3",
+            "textextensions": "2"
+          }
+        },
+        "isurl": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
+          }
+        },
+        "jest": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "import-local": "^1.0.0",
+            "jest-cli": "^22.4.4"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "jest-cli": {
+              "version": "22.4.4",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "import-local": "^1.0.0",
+                "is-ci": "^1.0.10",
+                "istanbul-api": "^1.1.14",
+                "istanbul-lib-coverage": "^1.1.1",
+                "istanbul-lib-instrument": "^1.8.0",
+                "istanbul-lib-source-maps": "^1.2.1",
+                "jest-changed-files": "^22.2.0",
+                "jest-config": "^22.4.4",
+                "jest-environment-jsdom": "^22.4.1",
+                "jest-get-type": "^22.1.0",
+                "jest-haste-map": "^22.4.2",
+                "jest-message-util": "^22.4.0",
+                "jest-regex-util": "^22.1.0",
+                "jest-resolve-dependencies": "^22.1.0",
+                "jest-runner": "^22.4.4",
+                "jest-runtime": "^22.4.4",
+                "jest-snapshot": "^22.4.0",
+                "jest-util": "^22.4.1",
+                "jest-validate": "^22.4.4",
+                "jest-worker": "^22.2.2",
+                "micromatch": "^2.3.11",
+                "node-notifier": "^5.2.1",
+                "realpath-native": "^1.0.0",
+                "rimraf": "^2.5.4",
+                "slash": "^1.0.0",
+                "string-length": "^2.0.0",
+                "strip-ansi": "^4.0.0",
+                "which": "^1.2.12",
+                "yargs": "^10.0.3"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "yargs": {
+              "version": "10.1.2",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^8.1.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "8.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
+          }
+        },
+        "jest-changed-files": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-config": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "glob": "^7.1.1",
+            "jest-environment-jsdom": "^22.4.1",
+            "jest-environment-node": "^22.4.1",
+            "jest-get-type": "^22.1.0",
+            "jest-jasmine2": "^22.4.4",
+            "jest-regex-util": "^22.1.0",
+            "jest-resolve": "^22.4.2",
+            "jest-util": "^22.4.1",
+            "jest-validate": "^22.4.4",
+            "pretty-format": "^22.4.0"
+          }
+        },
+        "jest-diff": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "diff": "^3.2.0",
+            "jest-get-type": "^22.4.3",
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "jest-docblock": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "detect-newline": "^2.1.0"
+          }
+        },
+        "jest-environment-enzyme": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "jest-environment-jsdom": "^22.4.1"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "jest-mock": "^22.4.3",
+            "jest-util": "^22.4.3",
+            "jsdom": "^11.5.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "jest-mock": "^22.4.3",
+            "jest-util": "^22.4.3"
+          }
+        },
+        "jest-enzyme": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "enzyme-matchers": "^6.0.1",
+            "enzyme-to-json": "^3.3.0",
+            "jest-environment-enzyme": "^6.0.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "22.4.3",
+          "bundled": true
+        },
+        "jest-haste-map": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "fb-watchman": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "jest-docblock": "^22.4.3",
+            "jest-serializer": "^22.4.3",
+            "jest-worker": "^22.4.3",
+            "micromatch": "^2.3.11",
+            "sane": "^2.0.0"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            }
+          }
+        },
+        "jest-jasmine2": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "co": "^4.6.0",
+            "expect": "^22.4.0",
+            "graceful-fs": "^4.1.11",
+            "is-generator-fn": "^1.0.0",
+            "jest-diff": "^22.4.0",
+            "jest-matcher-utils": "^22.4.0",
+            "jest-message-util": "^22.4.0",
+            "jest-snapshot": "^22.4.0",
+            "jest-util": "^22.4.1",
+            "source-map-support": "^0.5.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "source-map-support": {
+              "version": "0.5.6",
+              "bundled": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            }
+          }
+        },
+        "jest-leak-detector": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.4.3",
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "jest-message-util": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0-beta.35",
+            "chalk": "^2.0.1",
+            "micromatch": "^2.3.11",
+            "slash": "^1.0.0",
+            "stack-utils": "^1.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            }
+          }
+        },
+        "jest-mock": {
+          "version": "22.4.3",
+          "bundled": true
+        },
+        "jest-regex-util": {
+          "version": "22.4.3",
+          "bundled": true
+        },
+        "jest-resolve": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "browser-resolve": "^1.11.2",
+            "chalk": "^2.0.1"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "jest-regex-util": "^22.4.3"
+          }
+        },
+        "jest-runner": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "exit": "^0.1.2",
+            "jest-config": "^22.4.4",
+            "jest-docblock": "^22.4.0",
+            "jest-haste-map": "^22.4.2",
+            "jest-jasmine2": "^22.4.4",
+            "jest-leak-detector": "^22.4.0",
+            "jest-message-util": "^22.4.0",
+            "jest-runtime": "^22.4.4",
+            "jest-util": "^22.4.1",
+            "jest-worker": "^22.2.2",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-runtime": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.0.0",
+            "babel-jest": "^22.4.4",
+            "babel-plugin-istanbul": "^4.1.5",
+            "chalk": "^2.0.1",
+            "convert-source-map": "^1.4.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.1.11",
+            "jest-config": "^22.4.4",
+            "jest-haste-map": "^22.4.2",
+            "jest-regex-util": "^22.1.0",
+            "jest-resolve": "^22.4.2",
+            "jest-util": "^22.4.1",
+            "jest-validate": "^22.4.4",
+            "json-stable-stringify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "realpath-native": "^1.0.0",
+            "slash": "^1.0.0",
+            "strip-bom": "3.0.0",
+            "write-file-atomic": "^2.1.0",
+            "yargs": "^10.0.3"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "babel-jest": {
+              "version": "22.4.4",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-istanbul": "^4.1.5",
+                "babel-preset-jest": "^22.4.4"
+              }
+            },
+            "babel-plugin-jest-hoist": {
+              "version": "22.4.4",
+              "bundled": true
+            },
+            "babel-preset-jest": {
+              "version": "22.4.4",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-jest-hoist": "^22.4.4",
+                "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+              }
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "write-file-atomic": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "yargs": {
+              "version": "10.1.2",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^8.1.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "8.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
+          }
+        },
+        "jest-serializer": {
+          "version": "22.4.3",
+          "bundled": true
+        },
+        "jest-snapshot": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-diff": "^22.4.3",
+            "jest-matcher-utils": "^22.4.3",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "jest-util": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "callsites": "^2.0.0",
+            "chalk": "^2.0.1",
+            "graceful-fs": "^4.1.11",
+            "is-ci": "^1.0.10",
+            "jest-message-util": "^22.4.3",
+            "mkdirp": "^0.5.1",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "jest-validate": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-config": "^22.4.4",
+            "jest-get-type": "^22.1.0",
+            "leven": "^2.1.0",
+            "pretty-format": "^22.4.0"
+          }
+        },
+        "jest-worker": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "merge-stream": "^1.0.1"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.11.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jscodeshift": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-flow-strip-types": "^6.8.0",
+            "babel-preset-es2015": "^6.9.0",
+            "babel-preset-stage-1": "^6.5.0",
+            "babel-register": "^6.9.0",
+            "babylon": "^7.0.0-beta.30",
+            "colors": "^1.1.2",
+            "flow-parser": "^0.*",
+            "lodash": "^4.13.1",
+            "micromatch": "^2.3.7",
+            "neo-async": "^2.5.0",
+            "node-dir": "0.1.8",
+            "nomnom": "^1.8.1",
+            "recast": "^0.14.1",
+            "temp": "^0.8.1",
+            "write-file-atomic": "^1.2.0"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            }
+          }
+        },
+        "jsdom": {
+          "version": "11.11.0",
+          "bundled": true,
+          "requires": {
+            "abab": "^1.0.4",
+            "acorn": "^5.3.0",
+            "acorn-globals": "^4.1.0",
+            "array-equal": "^1.0.0",
+            "cssom": ">= 0.3.2 < 0.4.0",
+            "cssstyle": ">= 0.3.1 < 0.4.0",
+            "data-urls": "^1.0.0",
+            "domexception": "^1.0.0",
+            "escodegen": "^1.9.0",
+            "html-encoding-sniffer": "^1.0.2",
+            "left-pad": "^1.2.0",
+            "nwsapi": "^2.0.0",
+            "parse5": "4.0.0",
+            "pn": "^1.1.0",
+            "request": "^2.83.0",
+            "request-promise-native": "^1.0.5",
+            "sax": "^1.2.4",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.3.3",
+            "w3c-hr-time": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.3",
+            "whatwg-mimetype": "^2.1.0",
+            "whatwg-url": "^6.4.1",
+            "ws": "^4.0.0",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "bundled": true
+        },
+        "json-buffer": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "~0.0.0"
+          }
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json3": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3"
+          }
+        },
+        "keyv": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "json-buffer": "3.0.0"
+          }
+        },
+        "killable": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "leb": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "left-pad": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "leven": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "listr": {
+          "version": "0.14.1",
+          "bundled": true,
+          "requires": {
+            "@samverschueren/stream-to-observable": "^0.3.0",
+            "cli-truncate": "^0.2.1",
+            "figures": "^1.7.0",
+            "indent-string": "^2.1.0",
+            "is-observable": "^1.1.0",
+            "is-promise": "^2.1.0",
+            "is-stream": "^1.1.0",
+            "listr-silent-renderer": "^1.1.1",
+            "listr-update-renderer": "^0.4.0",
+            "listr-verbose-renderer": "^0.4.0",
+            "log-symbols": "^1.0.2",
+            "log-update": "^1.0.2",
+            "ora": "^0.2.3",
+            "p-map": "^1.1.1",
+            "rxjs": "^6.1.0",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
+              }
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.0.0"
+              }
+            },
+            "rxjs": {
+              "version": "6.2.0",
+              "bundled": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "listr-silent-renderer": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "listr-update-renderer": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "cli-truncate": "^0.2.1",
+            "elegant-spinner": "^1.0.1",
+            "figures": "^1.7.0",
+            "indent-string": "^3.0.0",
+            "log-symbols": "^1.0.2",
+            "log-update": "^1.0.2",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
+              }
+            },
+            "indent-string": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "listr-verbose-renderer": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "cli-cursor": "^1.0.2",
+            "date-fns": "^1.27.2",
+            "figures": "^1.7.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^1.0.1"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
+              }
+            },
+            "onetime": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "loader-runner": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
         "lodash": {
           "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+          "bundled": true
+        },
+        "lodash-es": {
+          "version": "4.17.8",
+          "bundled": true
+        },
+        "lodash._baseisequal": {
+          "version": "3.0.7",
+          "bundled": true,
+          "requires": {
+            "lodash.isarray": "^3.0.0",
+            "lodash.istypedarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "bundled": true
+        },
+        "lodash.isequal": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "lodash._baseisequal": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0"
+          }
+        },
+        "lodash.istypedarray": {
+          "version": "3.0.6",
+          "bundled": true
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        },
+        "log-update": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^1.0.0",
+            "cli-cursor": "^1.0.2"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^1.0.1"
+              }
+            },
+            "onetime": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
+              }
+            }
+          }
+        },
+        "loglevel": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "loglevelnext": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "es6-symbol": "^3.1.1",
+            "object.assign": "^4.1.0"
+          }
+        },
+        "long": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "magic-string": {
+          "version": "0.22.5",
+          "bundled": true,
+          "requires": {
+            "vlq": "^0.2.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "makeerror": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "tmpl": "1.0.x"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "md5.js": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "mem-fs": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "through2": "^2.0.0",
+            "vinyl": "^1.1.0",
+            "vinyl-file": "^2.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.5.1",
+            "ejs": "^2.5.9",
+            "glob": "^7.0.3",
+            "globby": "^8.0.0",
+            "isbinaryfile": "^3.0.2",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "clone-stats": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "replace-ext": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "vinyl": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+              }
+            }
+          }
+        },
+        "memory-fs": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "meow": {
+          "version": "3.7.0",
+          "bundled": true,
+          "requires": {
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          }
+        },
+        "merge": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "merge-stream": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "merge2": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "3.1.9",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "miller-rabin": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "bundled": true,
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mimic-response": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimalistic-assert": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mississippi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^2.0.1",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "multicast-dns": {
+          "version": "6.2.3",
+          "bundled": true,
+          "requires": {
+            "dns-packet": "^1.3.1",
+            "thunky": "^1.0.2"
+          }
+        },
+        "multicast-dns-service-types": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "minimatch": "^3.0.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.10.0",
+          "bundled": true,
+          "optional": true
+        },
+        "nanomatch": {
+          "version": "1.2.9",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-odd": "^2.0.0",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "nearley": {
+          "version": "2.13.0",
+          "bundled": true,
+          "requires": {
+            "nomnom": "~1.6.2",
+            "railroad-diagrams": "^1.0.0",
+            "randexp": "0.4.6",
+            "semver": "^5.4.1"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "0.5.1",
+              "bundled": true
+            },
+            "nomnom": {
+              "version": "1.6.2",
+              "bundled": true,
+              "requires": {
+                "colors": "0.5.x",
+                "underscore": "~1.4.4"
+              }
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "bundled": true
+            }
+          }
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "neo-async": {
+          "version": "2.5.1",
+          "bundled": true
+        },
+        "next-tick": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "nice-try": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "node-dir": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "node-forge": {
+          "version": "0.7.5",
+          "bundled": true
+        },
+        "node-int64": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "node-libs-browser": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "assert": "^1.1.1",
+            "browserify-zlib": "^0.2.0",
+            "buffer": "^4.3.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "^1.0.0",
+            "crypto-browserify": "^3.11.0",
+            "domain-browser": "^1.1.1",
+            "events": "^1.0.0",
+            "https-browserify": "^1.0.0",
+            "os-browserify": "^0.3.0",
+            "path-browserify": "0.0.0",
+            "process": "^0.11.10",
+            "punycode": "^1.2.4",
+            "querystring-es3": "^0.2.0",
+            "readable-stream": "^2.3.3",
+            "stream-browserify": "^2.0.1",
+            "stream-http": "^2.7.2",
+            "string_decoder": "^1.0.0",
+            "timers-browserify": "^2.0.4",
+            "tty-browserify": "0.0.0",
+            "url": "^0.11.0",
+            "util": "^0.10.3",
+            "vm-browserify": "0.0.4"
+          }
+        },
+        "node-notifier": {
+          "version": "5.2.1",
+          "bundled": true,
+          "requires": {
+            "growly": "^1.3.0",
+            "semver": "^5.4.1",
+            "shellwords": "^0.1.1",
+            "which": "^1.3.0"
+          }
+        },
+        "nomnom": {
+          "version": "1.8.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "~0.4.0",
+            "underscore": "~1.6.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "~1.0.0",
+                "has-color": "~0.1.0",
+                "strip-ansi": "~0.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "normalize-url": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "nth-check": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "boolbase": "~1.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "nwsapi": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "object-is": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "bundled": true
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.assign": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
+        "object.entries": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.6.1",
+            "function-bind": "^1.1.0",
+            "has": "^1.0.1"
+          }
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
+          }
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "object.values": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.6.1",
+            "function-bind": "^1.1.0",
+            "has": "^1.0.1"
+          }
+        },
+        "obuf": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "opn": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "is-wsl": "^1.1.0"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "bundled": true
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "ora": {
+          "version": "0.2.3",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "cli-cursor": "^1.0.2",
+            "cli-spinners": "^0.1.2",
+            "object-assign": "^4.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^1.0.1"
+              }
+            },
+            "onetime": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "original": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "url-parse": "~1.4.0"
+          }
+        },
+        "os-browserify": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "output-file-sync": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.4",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "p-each-series": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "p-reduce": "^1.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-is-promise": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "p-lazy": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-map": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "p-reduce": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-timeout": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "pako": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
+          }
+        },
+        "parse-asn1": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "^4.0.0",
+            "browserify-aes": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "parse-passwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "bundled": true
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "pbkdf2": {
+          "version": "3.0.16",
+          "bundled": true,
+          "requires": {
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "pn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "portfinder": {
+          "version": "1.0.13",
+          "bundled": true,
+          "requires": {
+            "async": "^1.5.2",
+            "debug": "^2.2.0",
+            "mkdirp": "0.5.x"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "prettier": {
+          "version": "1.12.1",
+          "bundled": true
+        },
+        "pretty-bytes": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "pretty-format": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.11.10",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "progress": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.6.1",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "proxy-addr": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "forwarded": "~0.1.2",
+            "ipaddr.js": "1.6.0"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "public-encrypt": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "pump": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "querystringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "raf": {
+          "version": "3.4.0",
+          "bundled": true,
+          "requires": {
+            "performance-now": "^2.1.0"
+          }
+        },
+        "railroad-diagrams": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "randexp": {
+          "version": "0.4.6",
+          "bundled": true,
+          "requires": {
+            "discontinuous-range": "1.0.0",
+            "ret": "~0.1.10"
+          }
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "randombytes": {
+          "version": "2.0.6",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "randomfill": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "bundled": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": ">= 1.3.1 < 2"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "react": {
+          "version": "16.4.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.4.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-is": {
+          "version": "16.4.0",
+          "bundled": true
+        },
+        "react-reconciler": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-redux": {
+          "version": "5.0.7",
+          "bundled": true,
+          "requires": {
+            "hoist-non-react-statics": "^2.5.0",
+            "invariant": "^2.0.0",
+            "lodash": "^4.17.5",
+            "lodash-es": "^4.17.5",
+            "loose-envify": "^1.1.0",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-test-renderer": {
+          "version": "16.4.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.0",
+            "react-is": "^16.4.0"
+          }
+        },
+        "read-chunk": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "readable-stream": "^2.0.2",
+            "set-immediate-shim": "^1.0.1"
+          }
+        },
+        "realpath-native": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "util.promisify": "^1.0.0"
+          }
+        },
+        "recast": {
+          "version": "0.14.7",
+          "bundled": true,
+          "requires": {
+            "ast-types": "0.11.3",
+            "esprima": "~4.0.0",
+            "private": "~0.1.5",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "bundled": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.2.1",
+            "lodash-es": "^4.2.1",
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.0.3"
+          },
+          "dependencies": {
+            "symbol-observable": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "regenerator-transform": {
+          "version": "0.10.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
+          }
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "requires": {
+            "is-equal-shallow": "^0.1.3"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "regexpp": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "request": {
+          "version": "2.87.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.13.1"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "^1.1.0",
+            "tough-cookie": ">=2.3.3"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          },
+          "dependencies": {
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "requireindex": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "resolve": {
+          "version": "1.7.1",
+          "bundled": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        },
+        "resolve-cwd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "resolve-dir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "responselike": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "lowercase-keys": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "ripemd160": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "rollup": {
+          "version": "0.59.4",
+          "bundled": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "@types/node": "*"
+          }
+        },
+        "rollup-plugin-babel": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "rollup-pluginutils": "^1.5.0"
+          }
+        },
+        "rollup-plugin-commonjs": {
+          "version": "9.1.3",
+          "bundled": true,
+          "requires": {
+            "estree-walker": "^0.5.1",
+            "magic-string": "^0.22.4",
+            "resolve": "^1.5.0",
+            "rollup-pluginutils": "^2.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "estree-walker": {
+              "version": "0.5.2",
+              "bundled": true
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "rollup-pluginutils": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "estree-walker": "^0.5.2",
+                "micromatch": "^2.3.11"
+              }
+            }
+          }
+        },
+        "rollup-plugin-node-resolve": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^2.0.0",
+            "is-module": "^1.0.0",
+            "resolve": "^1.1.6"
+          },
+          "dependencies": {
+            "builtin-modules": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "rollup-plugin-replace": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "magic-string": "^0.22.4",
+            "minimatch": "^3.0.2",
+            "rollup-pluginutils": "^2.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "estree-walker": {
+              "version": "0.5.2",
+              "bundled": true
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "rollup-pluginutils": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "estree-walker": "^0.5.2",
+                "micromatch": "^2.3.11"
+              }
+            }
+          }
+        },
+        "rollup-plugin-uglify": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0-beta.47",
+            "uglify-js": "^3.3.25"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0-beta.49",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "7.0.0-beta.49"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0-beta.49",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
+              }
+            },
+            "commander": {
+              "version": "2.15.1",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "3.4.0",
+              "bundled": true,
+              "requires": {
+                "commander": "~2.15.0",
+                "source-map": "~0.6.1"
+              }
+            }
+          }
+        },
+        "rollup-pluginutils": {
+          "version": "1.5.2",
+          "bundled": true,
+          "requires": {
+            "estree-walker": "^0.2.1",
+            "minimatch": "^3.0.2"
+          }
+        },
+        "rst-selector-parser": {
+          "version": "2.2.3",
+          "bundled": true,
+          "requires": {
+            "lodash.flattendeep": "^4.4.0",
+            "nearley": "^2.7.10"
+          }
+        },
+        "rsvp": {
+          "version": "3.6.2",
+          "bundled": true
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "run-queue": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1"
+          }
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "rx-lite-aggregates": {
+          "version": "4.0.8",
+          "bundled": true,
+          "requires": {
+            "rx-lite": "*"
+          }
+        },
+        "rxjs": {
+          "version": "5.5.11",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "sane": {
+          "version": "2.5.2",
+          "bundled": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "capture-exit": "^1.2.0",
+            "exec-sh": "^0.2.0",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^1.2.3",
+            "micromatch": "^3.1.4",
+            "minimist": "^1.1.1",
+            "walker": "~1.0.5",
+            "watch": "~0.18.0"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "aproba": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "delegates": "^1.0.0",
+                    "readable-stream": "^2.0.6"
+                  }
+                },
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "chownr": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "deep-extend": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "detect-libc": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "optional": true
+                },
+                "fs-minipass": {
+                  "version": "1.2.5",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "minipass": "^2.2.1"
+                  }
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "aproba": "^1.0.3",
+                    "console-control-strings": "^1.0.0",
+                    "has-unicode": "^2.0.0",
+                    "object-assign": "^4.1.0",
+                    "signal-exit": "^3.0.0",
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wide-align": "^1.1.0"
+                  }
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.4",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  }
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "iconv-lite": {
+                  "version": "0.4.21",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "safer-buffer": "^2.1.0"
+                  }
+                },
+                "ignore-walk": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "minimatch": "^3.0.4"
+                  }
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "once": "^1.3.0",
+                    "wrappy": "1"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true
+                },
+                "ini": {
+                  "version": "1.3.5",
+                  "bundled": true,
+                  "optional": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "^1.0.0"
+                  }
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                },
+                "minipass": {
+                  "version": "2.2.4",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "^5.1.1",
+                    "yallist": "^3.0.0"
+                  }
+                },
+                "minizlib": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "minipass": "^2.2.1"
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "needle": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "debug": "^2.1.2",
+                    "iconv-lite": "^0.4.4",
+                    "sax": "^1.2.4"
+                  }
+                },
+                "node-pre-gyp": {
+                  "version": "0.10.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "detect-libc": "^1.0.2",
+                    "mkdirp": "^0.5.1",
+                    "needle": "^2.2.0",
+                    "nopt": "^4.0.1",
+                    "npm-packlist": "^1.1.6",
+                    "npmlog": "^4.0.2",
+                    "rc": "^1.1.7",
+                    "rimraf": "^2.6.1",
+                    "semver": "^5.3.0",
+                    "tar": "^4"
+                  }
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "abbrev": "1",
+                    "osenv": "^0.1.4"
+                  }
+                },
+                "npm-bundled": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "optional": true
+                },
+                "npm-packlist": {
+                  "version": "1.1.10",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "ignore-walk": "^3.0.1",
+                    "npm-bundled": "^1.0.1"
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "are-we-there-yet": "~1.1.2",
+                    "console-control-strings": "~1.1.0",
+                    "gauge": "~2.7.3",
+                    "set-blocking": "~2.0.0"
+                  }
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "wrappy": "1"
+                  }
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "osenv": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "os-homedir": "^1.0.0",
+                    "os-tmpdir": "^1.0.0"
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "process-nextick-args": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "rc": {
+                  "version": "1.2.7",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "deep-extend": "^0.5.1",
+                    "ini": "~1.3.0",
+                    "minimist": "^1.2.0",
+                    "strip-json-comments": "~2.0.1"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.3.6",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "glob": "^7.0.5"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "bundled": true
+                },
+                "safer-buffer": {
+                  "version": "2.1.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "sax": {
+                  "version": "1.2.4",
+                  "bundled": true,
+                  "optional": true
+                },
+                "semver": {
+                  "version": "5.5.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  }
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "tar": {
+                  "version": "4.4.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "chownr": "^1.0.1",
+                    "fs-minipass": "^1.2.5",
+                    "minipass": "^2.2.4",
+                    "minizlib": "^1.1.0",
+                    "mkdirp": "^0.5.0",
+                    "safe-buffer": "^5.1.1",
+                    "yallist": "^3.0.2"
+                  }
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "string-width": "^1.0.2"
+                  }
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "yallist": {
+                  "version": "3.0.2",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "schema-utils": {
+          "version": "0.4.5",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "scoped-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "select-hose": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "selfsigned": {
+          "version": "1.10.3",
+          "bundled": true,
+          "requires": {
+            "node-forge": "0.7.5"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "send": {
+          "version": "0.16.2",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "serialize-javascript": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "serve-index": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "batch": "0.6.1",
+            "debug": "2.6.9",
+            "escape-html": "~1.0.3",
+            "http-errors": "~1.6.2",
+            "mime-types": "~2.1.17",
+            "parseurl": "~1.3.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.13.2",
+          "bundled": true,
+          "requires": {
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
+            "send": "0.16.2"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "sha.js": {
+          "version": "2.4.11",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          }
+        },
+        "shellwords": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "sockjs": {
+          "version": "0.3.19",
+          "bundled": true,
+          "requires": {
+            "faye-websocket": "^0.10.0",
+            "uuid": "^3.0.1"
+          }
+        },
+        "sockjs-client": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.6",
+            "eventsource": "0.1.6",
+            "faye-websocket": "~0.11.0",
+            "inherits": "^2.0.1",
+            "json3": "^3.3.2",
+            "url-parse": "^1.1.8"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "faye-websocket": {
+              "version": "0.11.1",
+              "bundled": true,
+              "requires": {
+                "websocket-driver": ">=0.5.1"
+              }
+            }
+          }
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
+        "source-list-map": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "atob": "^2.0.0",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "bundled": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "spdy": {
+          "version": "3.4.7",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "handle-thing": "^1.2.5",
+            "http-deceiver": "^1.2.7",
+            "safe-buffer": "^5.0.1",
+            "select-hose": "^2.0.0",
+            "spdy-transport": "^2.0.18"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "spdy-transport": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "detect-node": "^2.0.3",
+            "hpack.js": "^2.1.6",
+            "obuf": "^1.1.1",
+            "readable-stream": "^2.2.9",
+            "safe-buffer": "^5.0.1",
+            "wbuf": "^1.7.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "ssri": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "stack-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "stream-browserify": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "stream-each": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "stream-http": {
+          "version": "2.8.2",
+          "bundled": true,
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "string-length": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "astral-regex": "^1.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "string-template": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-bom-stream": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "first-chunk-stream": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "table": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            },
+            "ajv-keywords": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "slice-ansi": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0"
+              }
+            }
+          }
+        },
+        "tapable": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "temp": {
+          "version": "0.8.3",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "bundled": true
+            }
+          }
+        },
+        "test-exclude": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "micromatch": "^3.1.8",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "textextensions": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "throat": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        },
+        "thunky": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "timers-browserify": {
+          "version": "2.0.10",
+          "bundled": true,
+          "requires": {
+            "setimmediate": "^1.0.4"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "tmpl": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "to-arraybuffer": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "bundled": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "tslib": {
+          "version": "1.9.1",
+          "bundled": true
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-is": {
+          "version": "1.6.16",
+          "bundled": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.18"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.17",
+          "bundled": true
+        },
+        "uglify-es": {
+          "version": "3.3.9",
+          "bundled": true,
+          "requires": {
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "cacache": "^10.0.4",
+            "find-cache-dir": "^1.0.0",
+            "schema-utils": "^0.4.5",
+            "serialize-javascript": "^1.4.0",
+            "source-map": "^0.6.1",
+            "uglify-es": "^3.3.4",
+            "webpack-sources": "^1.1.0",
+            "worker-farm": "^1.5.2"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "unique-filename": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "unique-slug": "^2.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true
+            }
+          }
+        },
+        "untildify": {
+          "version": "3.0.3",
+          "bundled": true
+        },
+        "upath": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "uri-js": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "url": {
+          "version": "0.11.0",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "bundled": true
+            }
+          }
+        },
+        "url-join": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "url-parse": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "querystringify": "^2.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        },
+        "url-to-options": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "urlgrey": {
+          "version": "0.4.4",
+          "bundled": true
+        },
+        "use": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^6.0.2"
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.1"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "util.promisify": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "v8-compile-cache": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "v8flags": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "user-home": "^1.1.1"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "vary": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        },
+        "vinyl-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.3.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0",
+            "strip-bom-stream": "^2.0.0",
+            "vinyl": "^1.1.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "vlq": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "bundled": true,
+          "requires": {
+            "indexof": "0.0.1"
+          }
+        },
+        "w3c-hr-time": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browser-process-hrtime": "^0.1.2"
+          }
+        },
+        "walker": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "makeerror": "1.0.x"
+          }
+        },
+        "watch": {
+          "version": "0.18.0",
+          "bundled": true,
+          "requires": {
+            "exec-sh": "^0.2.0",
+            "minimist": "^1.2.0"
+          }
+        },
+        "watchpack": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "chokidar": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "neo-async": "^2.5.0"
+          }
+        },
+        "wbuf": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "webassemblyjs": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/validation": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "@webassemblyjs/wast-parser": "1.4.3",
+            "long": "^3.2.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "webpack": {
+          "version": "4.8.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/wasm-edit": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "acorn": "^5.0.0",
+            "acorn-dynamic-import": "^3.0.0",
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0",
+            "chrome-trace-event": "^0.1.1",
+            "enhanced-resolve": "^4.0.0",
+            "eslint-scope": "^3.7.1",
+            "loader-runner": "^2.3.0",
+            "loader-utils": "^1.1.0",
+            "memory-fs": "~0.4.1",
+            "micromatch": "^3.1.8",
+            "mkdirp": "~0.5.0",
+            "neo-async": "^2.5.0",
+            "node-libs-browser": "^2.0.0",
+            "schema-utils": "^0.4.4",
+            "tapable": "^1.0.0",
+            "uglifyjs-webpack-plugin": "^1.2.4",
+            "watchpack": "^1.5.0",
+            "webpack-sources": "^1.0.1"
+          }
+        },
+        "webpack-addons": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "jscodeshift": "^0.4.0"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "ast-types": {
+              "version": "0.10.1",
+              "bundled": true
+            },
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "jscodeshift": {
+              "version": "0.4.1",
+              "bundled": true,
+              "requires": {
+                "async": "^1.5.0",
+                "babel-plugin-transform-flow-strip-types": "^6.8.0",
+                "babel-preset-es2015": "^6.9.0",
+                "babel-preset-stage-1": "^6.5.0",
+                "babel-register": "^6.9.0",
+                "babylon": "^6.17.3",
+                "colors": "^1.1.2",
+                "flow-parser": "^0.*",
+                "lodash": "^4.13.1",
+                "micromatch": "^2.3.7",
+                "node-dir": "0.1.8",
+                "nomnom": "^1.8.1",
+                "recast": "^0.12.5",
+                "temp": "^0.8.1",
+                "write-file-atomic": "^1.2.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "recast": {
+              "version": "0.12.9",
+              "bundled": true,
+              "requires": {
+                "ast-types": "0.10.1",
+                "core-js": "^2.4.1",
+                "esprima": "~4.0.0",
+                "private": "~0.1.5",
+                "source-map": "~0.6.1"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "webpack-cli": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "cross-spawn": "^6.0.5",
+            "diff": "^3.5.0",
+            "enhanced-resolve": "^4.0.0",
+            "envinfo": "^5.7.0",
+            "glob-all": "^3.1.0",
+            "global-modules": "^1.0.0",
+            "got": "^8.3.1",
+            "import-local": "^1.0.0",
+            "inquirer": "^5.2.0",
+            "interpret": "^1.1.0",
+            "jscodeshift": "^0.5.0",
+            "listr": "^0.14.1",
+            "loader-utils": "^1.1.0",
+            "lodash": "^4.17.10",
+            "log-symbols": "^2.2.0",
+            "mkdirp": "^0.5.1",
+            "p-each-series": "^1.0.0",
+            "p-lazy": "^1.0.0",
+            "prettier": "^1.12.1",
+            "supports-color": "^5.4.0",
+            "v8-compile-cache": "^2.0.0",
+            "webpack-addons": "^1.1.5",
+            "yargs": "^11.1.0",
+            "yeoman-environment": "^2.1.1",
+            "yeoman-generator": "^2.0.5"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.1",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "supports-color": {
+              "version": "5.4.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "webpack-dev-middleware": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "loud-rejection": "^1.6.0",
+            "memory-fs": "~0.4.1",
+            "mime": "^2.1.0",
+            "path-is-absolute": "^1.0.0",
+            "range-parser": "^1.0.3",
+            "url-join": "^4.0.0",
+            "webpack-log": "^1.0.1"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "2.3.1",
+              "bundled": true
+            }
+          }
+        },
+        "webpack-dev-server": {
+          "version": "3.1.4",
+          "bundled": true,
+          "requires": {
+            "ansi-html": "0.0.7",
+            "array-includes": "^3.0.3",
+            "bonjour": "^3.5.0",
+            "chokidar": "^2.0.0",
+            "compression": "^1.5.2",
+            "connect-history-api-fallback": "^1.3.0",
+            "debug": "^3.1.0",
+            "del": "^3.0.0",
+            "express": "^4.16.2",
+            "html-entities": "^1.2.0",
+            "http-proxy-middleware": "~0.18.0",
+            "import-local": "^1.0.0",
+            "internal-ip": "1.2.0",
+            "ip": "^1.1.5",
+            "killable": "^1.0.0",
+            "loglevel": "^1.4.1",
+            "opn": "^5.1.0",
+            "portfinder": "^1.0.9",
+            "selfsigned": "^1.9.1",
+            "serve-index": "^1.7.2",
+            "sockjs": "0.3.19",
+            "sockjs-client": "1.1.4",
+            "spdy": "^3.4.1",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^5.1.0",
+            "webpack-dev-middleware": "3.1.3",
+            "webpack-log": "^1.1.2",
+            "yargs": "11.0.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "11.0.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
+              }
+            }
+          }
+        },
+        "webpack-log": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.1.0",
+            "log-symbols": "^2.1.0",
+            "loglevelnext": "^1.0.1",
+            "uuid": "^3.1.0"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "websocket-driver": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "http-parser-js": ">=0.4.0",
+            "websocket-extensions": ">=0.1.1"
+          }
+        },
+        "websocket-extensions": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "whatwg-mimetype": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "6.4.1",
+          "bundled": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "worker-farm": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "errno": "~0.1.7"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
+        },
+        "ws": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        },
+        "yeoman-environment": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "diff": "^3.3.1",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^8.0.1",
+            "grouped-queue": "^0.3.3",
+            "inquirer": "^5.2.0",
+            "is-scoped": "^1.0.0",
+            "lodash": "^4.17.10",
+            "log-symbols": "^2.1.0",
+            "mem-fs": "^1.1.0",
+            "strip-ansi": "^4.0.0",
+            "text-table": "^0.2.0",
+            "untildify": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "async": "^2.6.0",
+            "chalk": "^2.3.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^6.0.5",
+            "dargs": "^5.1.0",
+            "dateformat": "^3.0.3",
+            "debug": "^3.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^4.0.0",
+            "istextorbinary": "^2.2.1",
+            "lodash": "^4.17.10",
+            "make-dir": "^1.1.0",
+            "mem-fs-editor": "^4.0.0",
+            "minimist": "^1.2.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.1.0",
+            "read-pkg-up": "^3.0.0",
+            "rimraf": "^2.6.2",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.8.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "yeoman-environment": "^2.0.5"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "^4.17.10"
+              }
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
         }
       }
     },

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "fresh-data": "github:coderkevin/fresh-data",
+    "fresh-data": "file:../../",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-redux": "^5.0.7",

--- a/examples/wp-rest-api/package-lock.json
+++ b/examples/wp-rest-api/package-lock.json
@@ -253,6 +253,11 @@
         "commander": "^2.11.0"
       }
     },
+    "arity-n": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arity-n/-/arity-n-1.0.4.tgz",
+      "integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U="
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -478,6 +483,14 @@
         "source-map": "^0.5.6"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1234,6 +1247,16 @@
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
         "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "babel-types": {
@@ -1363,6 +1386,14 @@
         "type-is": "~1.6.15"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "iconv-lite": {
           "version": "0.4.19",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -1745,6 +1776,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
+    "chickencurry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chickencurry/-/chickencurry-1.1.1.tgz",
+      "integrity": "sha1-AmVfKyazvC7hrh5TFoht4463lzg="
+    },
     "chokidar": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
@@ -2011,6 +2047,14 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
+    "compose-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compose-function/-/compose-function-2.0.0.tgz",
+      "integrity": "sha1-5kL6fh2iFSlyADFHZ3b8JGkawLA=",
+      "requires": {
+        "arity-n": "^1.0.4"
+      }
+    },
     "compressible": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
@@ -2040,6 +2084,14 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -2496,9 +2548,9 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -2652,6 +2704,16 @@
       "requires": {
         "address": "^1.0.1",
         "debug": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "diff": {
@@ -3116,6 +3178,16 @@
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-loader": {
@@ -3139,6 +3211,14 @@
         "pkg-dir": "^1.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -3191,6 +3271,14 @@
         "read-pkg-up": "^2.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -3406,6 +3494,14 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -3519,6 +3615,14 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "path-to-regexp": {
           "version": "0.1.7",
@@ -3774,6 +3878,16 @@
         "parseurl": "~1.3.2",
         "statuses": "~1.4.0",
         "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "find-cache-dir": {
@@ -3878,6 +3992,11135 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fresh-data": {
+      "version": "file:../..",
+      "requires": {
+        "prop-types": "^15.6.1"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.42",
+          "bundled": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.42"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.44",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0-beta.44",
+            "@babel/template": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.44"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "7.0.0-beta.44"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.42",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44",
+            "babylon": "7.0.0-beta.44",
+            "lodash": "^4.2.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "7.0.0-beta.44"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.44",
+            "@babel/generator": "7.0.0-beta.44",
+            "@babel/helper-function-name": "7.0.0-beta.44",
+            "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44",
+            "babylon": "7.0.0-beta.44",
+            "debug": "^3.1.0",
+            "globals": "^11.1.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "7.0.0-beta.44"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
+              }
+            },
+            "globals": {
+              "version": "11.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0-beta.44",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^2.0.0"
+          },
+          "dependencies": {
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "@mrmlnc/readdir-enhanced": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "glob-to-regexp": "^0.3.0"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "@samverschueren/stream-to-observable": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "any-observable": "^0.3.0"
+          }
+        },
+        "@sindresorhus/is": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "@types/estree": {
+          "version": "0.0.39",
+          "bundled": true
+        },
+        "@types/node": {
+          "version": "10.1.4",
+          "bundled": true
+        },
+        "@webassemblyjs/ast": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/wast-parser": "1.4.3",
+            "debug": "^3.1.0",
+            "webassemblyjs": "1.4.3"
+          }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-buffer": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "debug": "^3.1.0"
+          }
+        },
+        "@webassemblyjs/helper-code-frame": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/wast-printer": "1.4.3"
+          }
+        },
+        "@webassemblyjs/helper-fsm": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-buffer": "1.4.3",
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/wasm-gen": "1.4.3",
+            "debug": "^3.1.0"
+          }
+        },
+        "@webassemblyjs/leb128": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "leb": "^0.3.0"
+          }
+        },
+        "@webassemblyjs/validation": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3"
+          }
+        },
+        "@webassemblyjs/wasm-edit": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-buffer": "1.4.3",
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/helper-wasm-section": "1.4.3",
+            "@webassemblyjs/wasm-gen": "1.4.3",
+            "@webassemblyjs/wasm-opt": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "@webassemblyjs/wast-printer": "1.4.3",
+            "debug": "^3.1.0"
+          }
+        },
+        "@webassemblyjs/wasm-gen": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/leb128": "1.4.3"
+          }
+        },
+        "@webassemblyjs/wasm-opt": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-buffer": "1.4.3",
+            "@webassemblyjs/wasm-gen": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "debug": "^3.1.0"
+          }
+        },
+        "@webassemblyjs/wasm-parser": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/helper-wasm-bytecode": "1.4.3",
+            "@webassemblyjs/leb128": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "webassemblyjs": "1.4.3"
+          }
+        },
+        "@webassemblyjs/wast-parser": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/floating-point-hex-parser": "1.4.3",
+            "@webassemblyjs/helper-code-frame": "1.4.3",
+            "@webassemblyjs/helper-fsm": "1.4.3",
+            "long": "^3.2.0",
+            "webassemblyjs": "1.4.3"
+          }
+        },
+        "@webassemblyjs/wast-printer": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/wast-parser": "1.4.3",
+            "long": "^3.2.0"
+          }
+        },
+        "abab": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "accepts": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "mime-types": "~2.1.18",
+            "negotiator": "0.6.1"
+          }
+        },
+        "acorn": {
+          "version": "5.5.3",
+          "bundled": true
+        },
+        "acorn-dynamic-import": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.0.0"
+          }
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.0.0"
+          }
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "6.5.0",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "uri-js": "^4.2.1"
+          },
+          "dependencies": {
+            "fast-deep-equal": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "ansi-html": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "any-observable": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "default-require-extensions": "^1.0.0"
+          }
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "argv": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "aria-query": {
+          "version": "0.7.1",
+          "bundled": true,
+          "requires": {
+            "ast-types-flow": "0.0.7",
+            "commander": "^2.11.0"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "array-differ": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "array-flatten": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "array-includes": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.7.0"
+          }
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "asn1.js": {
+          "version": "4.10.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "assert": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "util": "0.10.3"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ast-types": {
+          "version": "0.11.3",
+          "bundled": true
+        },
+        "ast-types-flow": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "astral-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "atob": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "axobject-query": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "ast-types-flow": "0.0.7"
+          }
+        },
+        "babel-cli": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "chokidar": "^1.6.1",
+            "commander": "^2.11.0",
+            "convert-source-map": "^1.5.0",
+            "fs-readdir-recursive": "^1.0.0",
+            "glob": "^7.1.2",
+            "lodash": "^4.17.4",
+            "output-file-sync": "^1.1.2",
+            "path-is-absolute": "^1.0.1",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.6",
+            "v8flags": "^2.1.1"
+          },
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
+              }
+            },
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "chokidar": {
+              "version": "1.7.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-glob": "^2.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            }
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-core": {
+          "version": "6.26.3",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.1",
+            "debug": "^2.6.9",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.8",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.7"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "babel-eslint": {
+          "version": "8.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0-beta.44",
+            "@babel/traverse": "7.0.0-beta.44",
+            "@babel/types": "7.0.0-beta.44",
+            "babylon": "7.0.0-beta.44",
+            "eslint-scope": "~3.7.1",
+            "eslint-visitor-keys": "^1.0.0"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "7.0.0-beta.44"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0-beta.44",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
+              }
+            }
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-helper-bindify-decorators": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-assignable-expression": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-builder-react-jsx": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "esutils": "^2.0.2"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-define-map": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-explode-class": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-bindify-decorators": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-jest": {
+          "version": "23.0.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-istanbul": "^4.1.6",
+            "babel-preset-jest": "^23.0.1"
+          }
+        },
+        "babel-loader": {
+          "version": "7.1.4",
+          "bundled": true,
+          "requires": {
+            "find-cache-dir": "^1.0.0",
+            "loader-utils": "^1.0.2",
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-external-helpers": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "4.1.6",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+            "find-up": "^2.1.0",
+            "istanbul-lib-instrument": "^1.10.1",
+            "test-exclude": "^4.2.1"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "23.0.1",
+          "bundled": true
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-async-generators": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-class-constructor-call": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-class-properties": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-decorators": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-dynamic-import": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-export-extensions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-flow": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-async-generator-functions": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-generators": "^6.5.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-class-constructor-call": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-class-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-plugin-syntax-class-properties": "^6.8.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-decorators": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-class": "^6.24.1",
+            "babel-plugin-syntax-decorators": "^6.13.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-define-map": "^6.24.1",
+            "babel-helper-function-name": "^6.24.1",
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.26.2",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-types": "^6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-call-delegate": "^6.24.1",
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "regexpu-core": "^2.0.0"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-export-extensions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-export-extensions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-flow-strip-types": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-flow": "^6.18.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-object-rest-spread": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+            "babel-runtime": "^6.26.0"
+          }
+        },
+        "babel-plugin-transform-react-display-name": {
+          "version": "6.25.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-react-jsx": "^6.24.1",
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-self": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-source": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "regenerator-transform": "^0.10.0"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-polyfill": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "regenerator-runtime": "^0.10.5"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "bundled": true
+            }
+          }
+        },
+        "babel-preset-env": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "^6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+            "babel-plugin-transform-async-to-generator": "^6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+            "babel-plugin-transform-es2015-classes": "^6.23.0",
+            "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+            "babel-plugin-transform-es2015-for-of": "^6.23.0",
+            "babel-plugin-transform-es2015-function-name": "^6.22.0",
+            "babel-plugin-transform-es2015-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+            "babel-plugin-transform-es2015-object-super": "^6.22.0",
+            "babel-plugin-transform-es2015-parameters": "^6.23.0",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-spread": "^6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+            "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+            "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+            "babel-plugin-transform-regenerator": "^6.22.0",
+            "browserslist": "^3.2.6",
+            "invariant": "^2.2.2",
+            "semver": "^5.3.0"
+          }
+        },
+        "babel-preset-es2015": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "^6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+            "babel-plugin-transform-es2015-classes": "^6.24.1",
+            "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+            "babel-plugin-transform-es2015-for-of": "^6.22.0",
+            "babel-plugin-transform-es2015-function-name": "^6.24.1",
+            "babel-plugin-transform-es2015-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+            "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+            "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+            "babel-plugin-transform-es2015-object-super": "^6.24.1",
+            "babel-plugin-transform-es2015-parameters": "^6.24.1",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+            "babel-plugin-transform-es2015-spread": "^6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+            "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+            "babel-plugin-transform-regenerator": "^6.24.1"
+          }
+        },
+        "babel-preset-flow": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-flow-strip-types": "^6.22.0"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "23.0.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "^23.0.1",
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+          }
+        },
+        "babel-preset-react": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.3.13",
+            "babel-plugin-transform-react-display-name": "^6.23.0",
+            "babel-plugin-transform-react-jsx": "^6.24.1",
+            "babel-plugin-transform-react-jsx-self": "^6.22.0",
+            "babel-plugin-transform-react-jsx-source": "^6.22.0",
+            "babel-preset-flow": "^6.23.0"
+          }
+        },
+        "babel-preset-stage-1": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-class-constructor-call": "^6.24.1",
+            "babel-plugin-transform-export-extensions": "^6.22.0",
+            "babel-preset-stage-2": "^6.24.1"
+          }
+        },
+        "babel-preset-stage-2": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-dynamic-import": "^6.18.0",
+            "babel-plugin-transform-class-properties": "^6.24.1",
+            "babel-plugin-transform-decorators": "^6.24.1",
+            "babel-preset-stage-3": "^6.24.1"
+          }
+        },
+        "babel-preset-stage-3": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+            "babel-plugin-transform-async-generator-functions": "^6.24.1",
+            "babel-plugin-transform-async-to-generator": "^6.24.1",
+            "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+            "babel-plugin-transform-object-rest-spread": "^6.22.0"
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            }
+          }
+        },
+        "base64-js": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "batch": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "big.js": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "binary-extensions": {
+          "version": "1.11.0",
+          "bundled": true
+        },
+        "binaryextensions": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "bundled": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "bundled": true
+        },
+        "body-parser": {
+          "version": "1.18.2",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "~1.6.15"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "bonjour": {
+          "version": "3.5.0",
+          "bundled": true,
+          "requires": {
+            "array-flatten": "^2.1.0",
+            "deep-equal": "^1.0.1",
+            "dns-equal": "^1.0.0",
+            "dns-txt": "^2.0.2",
+            "multicast-dns": "^6.0.1",
+            "multicast-dns-service-types": "^1.1.0"
+          }
+        },
+        "boolbase": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "kind-of": "^6.0.2",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "brorand": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "browser-process-hrtime": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "browser-resolve": {
+          "version": "1.11.2",
+          "bundled": true,
+          "requires": {
+            "resolve": "1.1.7"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.7",
+              "bundled": true
+            }
+          }
+        },
+        "browserify-aes": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "browserify-cipher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
+          }
+        },
+        "browserify-des": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "browserify-rsa": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "browserify-sign": {
+          "version": "4.0.4",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.1",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.2",
+            "elliptic": "^6.0.0",
+            "inherits": "^2.0.1",
+            "parse-asn1": "^5.0.0"
+          }
+        },
+        "browserify-zlib": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "pako": "~1.0.5"
+          }
+        },
+        "browserslist": {
+          "version": "3.2.8",
+          "bundled": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
+          }
+        },
+        "bser": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "node-int64": "^0.4.0"
+          }
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "bundled": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "buffer-from": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "buffer-indexof": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "buffer-xor": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtin-status-codes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "cacache": {
+          "version": "10.0.4",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.1",
+            "mississippi": "^2.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^5.2.4",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "cacheable-request": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "clone-response": "1.0.2",
+            "get-stream": "3.0.0",
+            "http-cache-semantics": "3.8.1",
+            "keyv": "3.0.0",
+            "lowercase-keys": "1.0.0",
+            "normalize-url": "2.0.1",
+            "responselike": "1.0.2"
+          },
+          "dependencies": {
+            "lowercase-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "call-me-maybe": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          },
+          "dependencies": {
+            "callsites": {
+              "version": "0.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "callsites": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000846",
+          "bundled": true
+        },
+        "capture-exit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "rsvp": "^3.3.3"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "cheerio": {
+          "version": "1.0.0-rc.2",
+          "bundled": true,
+          "requires": {
+            "css-select": "~1.2.0",
+            "dom-serializer": "~0.1.0",
+            "entities": "~1.1.1",
+            "htmlparser2": "^3.9.1",
+            "lodash": "^4.15.0",
+            "parse5": "^3.0.1"
+          },
+          "dependencies": {
+            "parse5": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "@types/node": "*"
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.0"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "chrome-trace-event": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "ci-info": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "cipher-base": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "bundled": true
+        },
+        "circular-json-es6": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-spinners": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "cli-table": {
+          "version": "0.3.1",
+          "bundled": true,
+          "requires": {
+            "colors": "1.0.3"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "cli-truncate": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "slice-ansi": "0.0.4",
+            "string-width": "^1.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "clone-buffer": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "clone-response": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "cloneable-readable": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "process-nextick-args": "^2.0.0",
+            "readable-stream": "^2.3.5"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "codecov": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "argv": "0.0.2",
+            "request": "^2.81.0",
+            "urlgrey": "0.4.4"
+          }
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "^1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.13.0",
+          "bundled": true
+        },
+        "comment-parser": {
+          "version": "0.4.2",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.0.4"
+          }
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "compare-versions": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "compressible": {
+          "version": "2.0.13",
+          "bundled": true,
+          "requires": {
+            "mime-db": ">= 1.33.0 < 2"
+          }
+        },
+        "compression": {
+          "version": "1.7.2",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "bytes": "3.0.0",
+            "compressible": "~2.0.13",
+            "debug": "2.6.9",
+            "on-headers": "~1.0.1",
+            "safe-buffer": "5.1.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "connect-history-api-fallback": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "date-now": "^0.1.4"
+          }
+        },
+        "constants-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
+          }
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "create-ecdh": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.0.0"
+          }
+        },
+        "create-hash": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
+          }
+        },
+        "create-hmac": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "cross-env": {
+          "version": "5.1.6",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^5.1.0",
+            "is-windows": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
+          }
+        },
+        "css-select": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+          }
+        },
+        "css-what": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "0.3.1",
+          "bundled": true,
+          "requires": {
+            "cssom": "0.3.x"
+          }
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "array-find-index": "^1.0.1"
+          }
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "d": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "es5-ext": "^0.10.9"
+          }
+        },
+        "damerau-levenshtein": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "dargs": {
+          "version": "5.1.0",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "data-urls": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "abab": "^1.0.4",
+            "whatwg-mimetype": "^2.0.0",
+            "whatwg-url": "^6.4.0"
+          }
+        },
+        "date-fns": {
+          "version": "1.29.0",
+          "bundled": true
+        },
+        "date-now": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "dateformat": {
+          "version": "3.0.3",
+          "bundled": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-equal-ident": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash.isequal": "^3.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "foreach": "^2.0.5",
+            "object-keys": "^1.0.8"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          }
+        },
+        "del": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "globby": {
+              "version": "6.1.0",
+              "bundled": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "depd": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "des.js": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "detect-conflict": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "detect-node": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "diff": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "diffie-hellman": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
+          }
+        },
+        "dir-glob": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "path-type": "^3.0.0"
+          },
+          "dependencies": {
+            "path-type": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            }
+          }
+        },
+        "discontinuous-range": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "dns-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "dns-packet": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "ip": "^1.1.0",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "dns-txt": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "buffer-indexof": "^1.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "dom-serializer": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "~1.1.1",
+            "entities": "~1.1.1"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.1.3",
+              "bundled": true
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "domelementtype": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "domexception": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "domhandler": {
+          "version": "2.4.2",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "duplexify": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
+        },
+        "editions": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ejs": {
+          "version": "2.6.1",
+          "bundled": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.48",
+          "bundled": true
+        },
+        "elegant-spinner": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "elliptic": {
+          "version": "6.4.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "6.5.1",
+          "bundled": true
+        },
+        "emojis-list": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "encodeurl": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.4.0",
+            "tapable": "^1.0.0"
+          }
+        },
+        "entities": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "envinfo": {
+          "version": "5.8.1",
+          "bundled": true
+        },
+        "enzyme": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "cheerio": "^1.0.0-rc.2",
+            "function.prototype.name": "^1.0.3",
+            "has": "^1.0.1",
+            "is-boolean-object": "^1.0.0",
+            "is-callable": "^1.1.3",
+            "is-number-object": "^1.0.3",
+            "is-string": "^1.0.4",
+            "is-subset": "^0.1.1",
+            "lodash": "^4.17.4",
+            "object-inspect": "^1.5.0",
+            "object-is": "^1.0.1",
+            "object.assign": "^4.1.0",
+            "object.entries": "^1.0.4",
+            "object.values": "^1.0.4",
+            "raf": "^3.4.0",
+            "rst-selector-parser": "^2.2.3"
+          }
+        },
+        "enzyme-adapter-react-16": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "enzyme-adapter-utils": "^1.3.0",
+            "lodash": "^4.17.4",
+            "object.assign": "^4.0.4",
+            "object.values": "^1.0.4",
+            "prop-types": "^15.6.0",
+            "react-reconciler": "^0.7.0",
+            "react-test-renderer": "^16.0.0-0"
+          }
+        },
+        "enzyme-adapter-utils": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.4",
+            "object.assign": "^4.0.4",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "enzyme-matchers": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "circular-json-es6": "^2.0.1",
+            "deep-equal-ident": "^1.1.1"
+          }
+        },
+        "enzyme-to-json": {
+          "version": "3.3.4",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.4"
+          }
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "prr": "~1.0.1"
+          }
+        },
+        "error": {
+          "version": "7.0.2",
+          "bundled": true,
+          "requires": {
+            "string-template": "~0.2.1",
+            "xtend": "~4.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.1",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.1"
+          }
+        },
+        "es5-ext": {
+          "version": "0.10.42",
+          "bundled": true,
+          "requires": {
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.1",
+            "next-tick": "1"
+          }
+        },
+        "es6-iterator": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "^0.10.35",
+            "es6-symbol": "^3.1.1"
+          }
+        },
+        "es6-symbol": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "escodegen": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "3.1.3",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "eslint": {
+          "version": "4.19.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "babel-code-frame": "^6.22.0",
+            "chalk": "^2.1.0",
+            "concat-stream": "^1.6.0",
+            "cross-spawn": "^5.1.0",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^3.7.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^3.5.4",
+            "esquery": "^1.0.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.0.1",
+            "ignore": "^3.3.3",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^3.0.6",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.9.1",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^1.0.1",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.3.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "4.0.2",
+            "text-table": "~0.2.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "globals": {
+              "version": "11.4.0",
+              "bundled": true
+            },
+            "inquirer": {
+              "version": "3.3.0",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "eslint-config-wordpress": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "eslint-plugin-i18n": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "eslint-plugin-jest": {
+          "version": "21.15.2",
+          "bundled": true
+        },
+        "eslint-plugin-jsdoc": {
+          "version": "3.5.0",
+          "bundled": true,
+          "requires": {
+            "comment-parser": "^0.4.2",
+            "lodash": "^4.17.4"
+          }
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "6.0.3",
+          "bundled": true,
+          "requires": {
+            "aria-query": "^0.7.0",
+            "array-includes": "^3.0.3",
+            "ast-types-flow": "0.0.7",
+            "axobject-query": "^0.1.0",
+            "damerau-levenshtein": "^1.0.0",
+            "emoji-regex": "^6.1.0",
+            "jsx-ast-utils": "^2.0.0"
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "ignore": "^3.3.6",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.3.3",
+            "semver": "^5.4.1"
+          }
+        },
+        "eslint-plugin-react": {
+          "version": "7.8.2",
+          "bundled": true,
+          "requires": {
+            "doctrine": "^2.0.2",
+            "has": "^1.0.1",
+            "jsx-ast-utils": "^2.0.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "eslint-plugin-wordpress": {
+          "version": "0.1.0",
+          "from": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git",
+          "bundled": true,
+          "requires": {
+            "eslint-plugin-i18n": "~1.2.0",
+            "eslint-plugin-jsdoc": "~3.5.0",
+            "eslint-plugin-node": "~6.0.1",
+            "eslint-plugin-wpcalypso": "~4.0.1",
+            "merge": "~1.2.0"
+          }
+        },
+        "eslint-plugin-wpcalypso": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "requireindex": "^1.1.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.1",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "espree": {
+          "version": "3.5.4",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "esquery": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "estree-walker": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "bundled": true
+        },
+        "eventemitter3": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "events": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "eventsource": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "original": ">=0.0.5"
+          }
+        },
+        "evp_bytestokey": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "exec-sh": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "merge": "^1.1.3"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "requires": {
+            "fill-range": "^2.1.0"
+          },
+          "dependencies": {
+            "fill-range": {
+              "version": "2.2.3",
+              "bundled": true,
+              "requires": {
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
+              }
+            },
+            "is-number": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "isobject": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "expand-tilde": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
+        "expect": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "jest-diff": "^22.4.3",
+            "jest-get-type": "^22.4.3",
+            "jest-matcher-utils": "^22.4.3",
+            "jest-message-util": "^22.4.3",
+            "jest-regex-util": "^22.4.3"
+          }
+        },
+        "express": {
+          "version": "4.16.3",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.5",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
+            "content-type": "~1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "1.1.1",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~2.0.3",
+            "qs": "6.5.1",
+            "range-parser": "~1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.2",
+            "serve-static": "1.13.2",
+            "setprototypeof": "1.1.0",
+            "statuses": "~1.4.0",
+            "type-is": "~1.6.16",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "array-flatten": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "external-editor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fast-glob": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.0.1",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.1",
+            "micromatch": "^3.1.10"
+          },
+          "dependencies": {
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            }
+          }
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "faye-websocket": {
+          "version": "0.10.0",
+          "bundled": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        },
+        "fb-watchman": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "bser": "^2.0.0"
+          }
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "bundled": true,
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.9"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "bundled": true
+            }
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fileset": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.3",
+            "minimatch": "^3.0.3"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "finalhandler": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.4.0",
+            "unpipe": "~1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "first-chunk-stream": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "circular-json": "^0.3.1",
+            "del": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "write": "^0.2.1"
+          },
+          "dependencies": {
+            "del": {
+              "version": "2.2.2",
+              "bundled": true,
+              "requires": {
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
+              }
+            },
+            "globby": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "flow-parser": {
+          "version": "0.73.0",
+          "bundled": true
+        },
+        "flush-write-stream": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^3.1.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.1"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fsevents": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.5.1",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.21",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": "^2.1.0"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.0",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.1.10",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.2.4",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "function.prototype.name": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "is-callable": "^1.1.3"
+          }
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "gh-got": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "got": "^7.0.0",
+            "is-plain-obj": "^1.1.0"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            },
+            "p-cancelable": {
+              "version": "0.3.0",
+              "bundled": true
+            },
+            "p-timeout": {
+              "version": "1.2.1",
+              "bundled": true,
+              "requires": {
+                "p-finally": "^1.0.0"
+              }
+            },
+            "prepend-http": {
+              "version": "1.0.4",
+              "bundled": true
+            },
+            "url-parse-lax": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "prepend-http": "^1.0.1"
+              }
+            }
+          }
+        },
+        "github-username": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "gh-got": "^6.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-all": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5",
+            "yargs": "~1.2.6"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "1.2.6",
+              "bundled": true,
+              "requires": {
+                "minimist": "^0.1.0"
+              }
+            }
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          },
+          "dependencies": {
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "^2.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "global-modules": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "8.0.1",
+          "bundled": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "got": {
+          "version": "8.3.1",
+          "bundled": true,
+          "requires": {
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "grouped-queue": {
+          "version": "0.3.3",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.2"
+          }
+        },
+        "growly": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "handle-thing": {
+          "version": "1.2.5",
+          "bundled": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.7",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            }
+          }
+        },
+        "harmony-reflect": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "has": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.0.2"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-color": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbol-support-x": {
+          "version": "1.4.2",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-to-string-tag-x": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "has-symbol-support-x": "^1.4.1"
+          }
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "hash-base": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "hmac-drbg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.0",
+          "bundled": true
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.1"
+          }
+        },
+        "homedir-polyfill": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "parse-passwd": "^1.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true
+        },
+        "hpack.js": {
+          "version": "2.1.6",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "obuf": "^1.0.0",
+            "readable-stream": "^2.0.1",
+            "wbuf": "^1.1.0"
+          }
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "whatwg-encoding": "^1.0.1"
+          }
+        },
+        "html-entities": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "bundled": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "bundled": true
+        },
+        "http-deceiver": {
+          "version": "1.2.7",
+          "bundled": true
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "bundled": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "http-parser-js": {
+          "version": "0.4.13",
+          "bundled": true
+        },
+        "http-proxy": {
+          "version": "1.17.0",
+          "bundled": true,
+          "requires": {
+            "eventemitter3": "^3.0.0",
+            "follow-redirects": "^1.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "0.18.0",
+          "bundled": true,
+          "requires": {
+            "http-proxy": "^1.16.2",
+            "is-glob": "^4.0.0",
+            "lodash": "^4.17.5",
+            "micromatch": "^3.1.9"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "identity-obj-proxy": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "harmony-reflect": "^1.4.6"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.11",
+          "bundled": true
+        },
+        "iferr": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "3.3.7",
+          "bundled": true
+        },
+        "import-local": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "pkg-dir": "^2.0.0",
+            "resolve-cwd": "^2.0.0"
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "internal-ip": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "meow": "^3.3.0"
+          }
+        },
+        "interpret": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "into-stream": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "from2": "^2.1.1",
+            "p-is-promise": "^1.1.0"
+          }
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "ipaddr.js": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-boolean-object": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "is-ci": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ci-info": "^1.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-generator-fn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-module": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-number-object": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-observable": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "^1.1.0"
+          },
+          "dependencies": {
+            "symbol-observable": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-odd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-scoped": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "scoped-regex": "^1.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-string": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "is-subset": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-wsl": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isbinaryfile": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "istanbul-api": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "async": "^2.1.4",
+            "compare-versions": "^3.1.0",
+            "fileset": "^2.0.2",
+            "istanbul-lib-coverage": "^1.2.0",
+            "istanbul-lib-hook": "^1.2.0",
+            "istanbul-lib-instrument": "^1.10.1",
+            "istanbul-lib-report": "^1.1.4",
+            "istanbul-lib-source-maps": "^1.2.4",
+            "istanbul-reports": "^1.3.0",
+            "js-yaml": "^3.7.0",
+            "mkdirp": "^0.5.1",
+            "once": "^1.4.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "^4.17.10"
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "1.2.4",
+              "bundled": true,
+              "requires": {
+                "debug": "^3.1.0",
+                "istanbul-lib-coverage": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.1",
+                "source-map": "^0.5.3"
+              }
+            },
+            "lodash": {
+              "version": "4.17.10",
+              "bundled": true
+            }
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "append-transform": "^0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.10.1",
+          "bundled": true,
+          "requires": {
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "semver": "^5.3.0"
+          },
+          "dependencies": {
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            }
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "istanbul-lib-coverage": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.3",
+          "bundled": true,
+          "requires": {
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "handlebars": "^4.0.3"
+          }
+        },
+        "istextorbinary": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "binaryextensions": "2",
+            "editions": "^1.3.3",
+            "textextensions": "2"
+          }
+        },
+        "isurl": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
+          }
+        },
+        "jest": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "import-local": "^1.0.0",
+            "jest-cli": "^22.4.4"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "jest-cli": {
+              "version": "22.4.4",
+              "bundled": true,
+              "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "import-local": "^1.0.0",
+                "is-ci": "^1.0.10",
+                "istanbul-api": "^1.1.14",
+                "istanbul-lib-coverage": "^1.1.1",
+                "istanbul-lib-instrument": "^1.8.0",
+                "istanbul-lib-source-maps": "^1.2.1",
+                "jest-changed-files": "^22.2.0",
+                "jest-config": "^22.4.4",
+                "jest-environment-jsdom": "^22.4.1",
+                "jest-get-type": "^22.1.0",
+                "jest-haste-map": "^22.4.2",
+                "jest-message-util": "^22.4.0",
+                "jest-regex-util": "^22.1.0",
+                "jest-resolve-dependencies": "^22.1.0",
+                "jest-runner": "^22.4.4",
+                "jest-runtime": "^22.4.4",
+                "jest-snapshot": "^22.4.0",
+                "jest-util": "^22.4.1",
+                "jest-validate": "^22.4.4",
+                "jest-worker": "^22.2.2",
+                "micromatch": "^2.3.11",
+                "node-notifier": "^5.2.1",
+                "realpath-native": "^1.0.0",
+                "rimraf": "^2.5.4",
+                "slash": "^1.0.0",
+                "string-length": "^2.0.0",
+                "strip-ansi": "^4.0.0",
+                "which": "^1.2.12",
+                "yargs": "^10.0.3"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "yargs": {
+              "version": "10.1.2",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^8.1.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "8.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
+          }
+        },
+        "jest-changed-files": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-config": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "glob": "^7.1.1",
+            "jest-environment-jsdom": "^22.4.1",
+            "jest-environment-node": "^22.4.1",
+            "jest-get-type": "^22.1.0",
+            "jest-jasmine2": "^22.4.4",
+            "jest-regex-util": "^22.1.0",
+            "jest-resolve": "^22.4.2",
+            "jest-util": "^22.4.1",
+            "jest-validate": "^22.4.4",
+            "pretty-format": "^22.4.0"
+          }
+        },
+        "jest-diff": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "diff": "^3.2.0",
+            "jest-get-type": "^22.4.3",
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "jest-docblock": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "detect-newline": "^2.1.0"
+          }
+        },
+        "jest-environment-enzyme": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "jest-environment-jsdom": "^22.4.1"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "jest-mock": "^22.4.3",
+            "jest-util": "^22.4.3",
+            "jsdom": "^11.5.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "jest-mock": "^22.4.3",
+            "jest-util": "^22.4.3"
+          }
+        },
+        "jest-enzyme": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "enzyme-matchers": "^6.0.1",
+            "enzyme-to-json": "^3.3.0",
+            "jest-environment-enzyme": "^6.0.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "22.4.3",
+          "bundled": true
+        },
+        "jest-haste-map": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "fb-watchman": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "jest-docblock": "^22.4.3",
+            "jest-serializer": "^22.4.3",
+            "jest-worker": "^22.4.3",
+            "micromatch": "^2.3.11",
+            "sane": "^2.0.0"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            }
+          }
+        },
+        "jest-jasmine2": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "co": "^4.6.0",
+            "expect": "^22.4.0",
+            "graceful-fs": "^4.1.11",
+            "is-generator-fn": "^1.0.0",
+            "jest-diff": "^22.4.0",
+            "jest-matcher-utils": "^22.4.0",
+            "jest-message-util": "^22.4.0",
+            "jest-snapshot": "^22.4.0",
+            "jest-util": "^22.4.1",
+            "source-map-support": "^0.5.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "source-map-support": {
+              "version": "0.5.6",
+              "bundled": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            }
+          }
+        },
+        "jest-leak-detector": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.4.3",
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "jest-message-util": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0-beta.35",
+            "chalk": "^2.0.1",
+            "micromatch": "^2.3.11",
+            "slash": "^1.0.0",
+            "stack-utils": "^1.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            }
+          }
+        },
+        "jest-mock": {
+          "version": "22.4.3",
+          "bundled": true
+        },
+        "jest-regex-util": {
+          "version": "22.4.3",
+          "bundled": true
+        },
+        "jest-resolve": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "browser-resolve": "^1.11.2",
+            "chalk": "^2.0.1"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "jest-regex-util": "^22.4.3"
+          }
+        },
+        "jest-runner": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "exit": "^0.1.2",
+            "jest-config": "^22.4.4",
+            "jest-docblock": "^22.4.0",
+            "jest-haste-map": "^22.4.2",
+            "jest-jasmine2": "^22.4.4",
+            "jest-leak-detector": "^22.4.0",
+            "jest-message-util": "^22.4.0",
+            "jest-runtime": "^22.4.4",
+            "jest-util": "^22.4.1",
+            "jest-worker": "^22.2.2",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-runtime": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.0.0",
+            "babel-jest": "^22.4.4",
+            "babel-plugin-istanbul": "^4.1.5",
+            "chalk": "^2.0.1",
+            "convert-source-map": "^1.4.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.1.11",
+            "jest-config": "^22.4.4",
+            "jest-haste-map": "^22.4.2",
+            "jest-regex-util": "^22.1.0",
+            "jest-resolve": "^22.4.2",
+            "jest-util": "^22.4.1",
+            "jest-validate": "^22.4.4",
+            "json-stable-stringify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "realpath-native": "^1.0.0",
+            "slash": "^1.0.0",
+            "strip-bom": "3.0.0",
+            "write-file-atomic": "^2.1.0",
+            "yargs": "^10.0.3"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "babel-jest": {
+              "version": "22.4.4",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-istanbul": "^4.1.5",
+                "babel-preset-jest": "^22.4.4"
+              }
+            },
+            "babel-plugin-jest-hoist": {
+              "version": "22.4.4",
+              "bundled": true
+            },
+            "babel-preset-jest": {
+              "version": "22.4.4",
+              "bundled": true,
+              "requires": {
+                "babel-plugin-jest-hoist": "^22.4.4",
+                "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+              }
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "write-file-atomic": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "yargs": {
+              "version": "10.1.2",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^8.1.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "8.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
+          }
+        },
+        "jest-serializer": {
+          "version": "22.4.3",
+          "bundled": true
+        },
+        "jest-snapshot": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-diff": "^22.4.3",
+            "jest-matcher-utils": "^22.4.3",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "jest-util": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "callsites": "^2.0.0",
+            "chalk": "^2.0.1",
+            "graceful-fs": "^4.1.11",
+            "is-ci": "^1.0.10",
+            "jest-message-util": "^22.4.3",
+            "mkdirp": "^0.5.1",
+            "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "jest-validate": {
+          "version": "22.4.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-config": "^22.4.4",
+            "jest-get-type": "^22.1.0",
+            "leven": "^2.1.0",
+            "pretty-format": "^22.4.0"
+          }
+        },
+        "jest-worker": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "merge-stream": "^1.0.1"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.11.0",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jscodeshift": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-flow-strip-types": "^6.8.0",
+            "babel-preset-es2015": "^6.9.0",
+            "babel-preset-stage-1": "^6.5.0",
+            "babel-register": "^6.9.0",
+            "babylon": "^7.0.0-beta.30",
+            "colors": "^1.1.2",
+            "flow-parser": "^0.*",
+            "lodash": "^4.13.1",
+            "micromatch": "^2.3.7",
+            "neo-async": "^2.5.0",
+            "node-dir": "0.1.8",
+            "nomnom": "^1.8.1",
+            "recast": "^0.14.1",
+            "temp": "^0.8.1",
+            "write-file-atomic": "^1.2.0"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            }
+          }
+        },
+        "jsdom": {
+          "version": "11.11.0",
+          "bundled": true,
+          "requires": {
+            "abab": "^1.0.4",
+            "acorn": "^5.3.0",
+            "acorn-globals": "^4.1.0",
+            "array-equal": "^1.0.0",
+            "cssom": ">= 0.3.2 < 0.4.0",
+            "cssstyle": ">= 0.3.1 < 0.4.0",
+            "data-urls": "^1.0.0",
+            "domexception": "^1.0.0",
+            "escodegen": "^1.9.0",
+            "html-encoding-sniffer": "^1.0.2",
+            "left-pad": "^1.2.0",
+            "nwsapi": "^2.0.0",
+            "parse5": "4.0.0",
+            "pn": "^1.1.0",
+            "request": "^2.83.0",
+            "request-promise-native": "^1.0.5",
+            "sax": "^1.2.4",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.3.3",
+            "w3c-hr-time": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.3",
+            "whatwg-mimetype": "^2.1.0",
+            "whatwg-url": "^6.4.1",
+            "ws": "^4.0.0",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "bundled": true
+        },
+        "json-buffer": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "~0.0.0"
+          }
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json3": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3"
+          }
+        },
+        "keyv": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "json-buffer": "3.0.0"
+          }
+        },
+        "killable": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "leb": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "left-pad": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "leven": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "listr": {
+          "version": "0.14.1",
+          "bundled": true,
+          "requires": {
+            "@samverschueren/stream-to-observable": "^0.3.0",
+            "cli-truncate": "^0.2.1",
+            "figures": "^1.7.0",
+            "indent-string": "^2.1.0",
+            "is-observable": "^1.1.0",
+            "is-promise": "^2.1.0",
+            "is-stream": "^1.1.0",
+            "listr-silent-renderer": "^1.1.1",
+            "listr-update-renderer": "^0.4.0",
+            "listr-verbose-renderer": "^0.4.0",
+            "log-symbols": "^1.0.2",
+            "log-update": "^1.0.2",
+            "ora": "^0.2.3",
+            "p-map": "^1.1.1",
+            "rxjs": "^6.1.0",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
+              }
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.0.0"
+              }
+            },
+            "rxjs": {
+              "version": "6.2.0",
+              "bundled": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "listr-silent-renderer": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "listr-update-renderer": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "cli-truncate": "^0.2.1",
+            "elegant-spinner": "^1.0.1",
+            "figures": "^1.7.0",
+            "indent-string": "^3.0.0",
+            "log-symbols": "^1.0.2",
+            "log-update": "^1.0.2",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
+              }
+            },
+            "indent-string": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "listr-verbose-renderer": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "cli-cursor": "^1.0.2",
+            "date-fns": "^1.27.2",
+            "figures": "^1.7.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^1.0.1"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
+              }
+            },
+            "onetime": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "loader-runner": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "bundled": true
+        },
+        "lodash-es": {
+          "version": "4.17.8",
+          "bundled": true
+        },
+        "lodash._baseisequal": {
+          "version": "3.0.7",
+          "bundled": true,
+          "requires": {
+            "lodash.isarray": "^3.0.0",
+            "lodash.istypedarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "bundled": true
+        },
+        "lodash.isequal": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "lodash._baseisequal": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0"
+          }
+        },
+        "lodash.istypedarray": {
+          "version": "3.0.6",
+          "bundled": true
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        },
+        "log-update": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^1.0.0",
+            "cli-cursor": "^1.0.2"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^1.0.1"
+              }
+            },
+            "onetime": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
+              }
+            }
+          }
+        },
+        "loglevel": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "loglevelnext": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "es6-symbol": "^3.1.1",
+            "object.assign": "^4.1.0"
+          }
+        },
+        "long": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "magic-string": {
+          "version": "0.22.5",
+          "bundled": true,
+          "requires": {
+            "vlq": "^0.2.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "makeerror": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "tmpl": "1.0.x"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "md5.js": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "mem-fs": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "through2": "^2.0.0",
+            "vinyl": "^1.1.0",
+            "vinyl-file": "^2.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.5.1",
+            "ejs": "^2.5.9",
+            "glob": "^7.0.3",
+            "globby": "^8.0.0",
+            "isbinaryfile": "^3.0.2",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "clone-stats": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "replace-ext": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "vinyl": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+              }
+            }
+          }
+        },
+        "memory-fs": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "meow": {
+          "version": "3.7.0",
+          "bundled": true,
+          "requires": {
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          }
+        },
+        "merge": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "merge-stream": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "merge2": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "3.1.9",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "miller-rabin": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "bundled": true,
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mimic-response": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimalistic-assert": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mississippi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^2.0.1",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            }
+          }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "multicast-dns": {
+          "version": "6.2.3",
+          "bundled": true,
+          "requires": {
+            "dns-packet": "^1.3.1",
+            "thunky": "^1.0.2"
+          }
+        },
+        "multicast-dns-service-types": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "minimatch": "^3.0.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.10.0",
+          "bundled": true,
+          "optional": true
+        },
+        "nanomatch": {
+          "version": "1.2.9",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-odd": "^2.0.0",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "nearley": {
+          "version": "2.13.0",
+          "bundled": true,
+          "requires": {
+            "nomnom": "~1.6.2",
+            "railroad-diagrams": "^1.0.0",
+            "randexp": "0.4.6",
+            "semver": "^5.4.1"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "0.5.1",
+              "bundled": true
+            },
+            "nomnom": {
+              "version": "1.6.2",
+              "bundled": true,
+              "requires": {
+                "colors": "0.5.x",
+                "underscore": "~1.4.4"
+              }
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "bundled": true
+            }
+          }
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "neo-async": {
+          "version": "2.5.1",
+          "bundled": true
+        },
+        "next-tick": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "nice-try": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "node-dir": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "node-forge": {
+          "version": "0.7.5",
+          "bundled": true
+        },
+        "node-int64": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "node-libs-browser": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "assert": "^1.1.1",
+            "browserify-zlib": "^0.2.0",
+            "buffer": "^4.3.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "^1.0.0",
+            "crypto-browserify": "^3.11.0",
+            "domain-browser": "^1.1.1",
+            "events": "^1.0.0",
+            "https-browserify": "^1.0.0",
+            "os-browserify": "^0.3.0",
+            "path-browserify": "0.0.0",
+            "process": "^0.11.10",
+            "punycode": "^1.2.4",
+            "querystring-es3": "^0.2.0",
+            "readable-stream": "^2.3.3",
+            "stream-browserify": "^2.0.1",
+            "stream-http": "^2.7.2",
+            "string_decoder": "^1.0.0",
+            "timers-browserify": "^2.0.4",
+            "tty-browserify": "0.0.0",
+            "url": "^0.11.0",
+            "util": "^0.10.3",
+            "vm-browserify": "0.0.4"
+          }
+        },
+        "node-notifier": {
+          "version": "5.2.1",
+          "bundled": true,
+          "requires": {
+            "growly": "^1.3.0",
+            "semver": "^5.4.1",
+            "shellwords": "^0.1.1",
+            "which": "^1.3.0"
+          }
+        },
+        "nomnom": {
+          "version": "1.8.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "~0.4.0",
+            "underscore": "~1.6.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "~1.0.0",
+                "has-color": "~0.1.0",
+                "strip-ansi": "~0.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "normalize-url": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "nth-check": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "boolbase": "~1.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "nwsapi": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "object-is": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "bundled": true
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.assign": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
+        "object.entries": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.6.1",
+            "function-bind": "^1.1.0",
+            "has": "^1.0.1"
+          }
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
+          }
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "object.values": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.6.1",
+            "function-bind": "^1.1.0",
+            "has": "^1.0.1"
+          }
+        },
+        "obuf": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "opn": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "is-wsl": "^1.1.0"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "bundled": true
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "ora": {
+          "version": "0.2.3",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "cli-cursor": "^1.0.2",
+            "cli-spinners": "^0.1.2",
+            "object-assign": "^4.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "restore-cursor": "^1.0.1"
+              }
+            },
+            "onetime": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "original": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "url-parse": "~1.4.0"
+          }
+        },
+        "os-browserify": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "output-file-sync": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.4",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "p-each-series": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "p-reduce": "^1.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-is-promise": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "p-lazy": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-map": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "p-reduce": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-timeout": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "pako": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
+          }
+        },
+        "parse-asn1": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "^4.0.0",
+            "browserify-aes": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            }
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "parse-passwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "bundled": true
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "pbkdf2": {
+          "version": "3.0.16",
+          "bundled": true,
+          "requires": {
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "pn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "portfinder": {
+          "version": "1.0.13",
+          "bundled": true,
+          "requires": {
+            "async": "^1.5.2",
+            "debug": "^2.2.0",
+            "mkdirp": "0.5.x"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "prettier": {
+          "version": "1.12.1",
+          "bundled": true
+        },
+        "pretty-bytes": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "pretty-format": {
+          "version": "22.4.3",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.11.10",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "progress": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.6.1",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "proxy-addr": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "forwarded": "~0.1.2",
+            "ipaddr.js": "1.6.0"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "public-encrypt": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "pump": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "querystringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "raf": {
+          "version": "3.4.0",
+          "bundled": true,
+          "requires": {
+            "performance-now": "^2.1.0"
+          }
+        },
+        "railroad-diagrams": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "randexp": {
+          "version": "0.4.6",
+          "bundled": true,
+          "requires": {
+            "discontinuous-range": "1.0.0",
+            "ret": "~0.1.10"
+          }
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "randombytes": {
+          "version": "2.0.6",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "randomfill": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "bundled": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": ">= 1.3.1 < 2"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "react": {
+          "version": "16.4.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.4.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-is": {
+          "version": "16.4.0",
+          "bundled": true
+        },
+        "react-reconciler": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-redux": {
+          "version": "5.0.7",
+          "bundled": true,
+          "requires": {
+            "hoist-non-react-statics": "^2.5.0",
+            "invariant": "^2.0.0",
+            "lodash": "^4.17.5",
+            "lodash-es": "^4.17.5",
+            "loose-envify": "^1.1.0",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-test-renderer": {
+          "version": "16.4.0",
+          "bundled": true,
+          "requires": {
+            "fbjs": "^0.8.16",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.0",
+            "react-is": "^16.4.0"
+          }
+        },
+        "read-chunk": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "readable-stream": "^2.0.2",
+            "set-immediate-shim": "^1.0.1"
+          }
+        },
+        "realpath-native": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "util.promisify": "^1.0.0"
+          }
+        },
+        "recast": {
+          "version": "0.14.7",
+          "bundled": true,
+          "requires": {
+            "ast-types": "0.11.3",
+            "esprima": "~4.0.0",
+            "private": "~0.1.5",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "bundled": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.2.1",
+            "lodash-es": "^4.2.1",
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.0.3"
+          },
+          "dependencies": {
+            "symbol-observable": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "regenerator-transform": {
+          "version": "0.10.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
+          }
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "requires": {
+            "is-equal-shallow": "^0.1.3"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "regexpp": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "request": {
+          "version": "2.87.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
+        "request-promise-core": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.13.1"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "request-promise-core": "1.1.1",
+            "stealthy-require": "^1.1.0",
+            "tough-cookie": ">=2.3.3"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          },
+          "dependencies": {
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "requireindex": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "resolve": {
+          "version": "1.7.1",
+          "bundled": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
+        },
+        "resolve-cwd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "resolve-dir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "responselike": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "lowercase-keys": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "ripemd160": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "rollup": {
+          "version": "0.59.4",
+          "bundled": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "@types/node": "*"
+          }
+        },
+        "rollup-plugin-babel": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "rollup-pluginutils": "^1.5.0"
+          }
+        },
+        "rollup-plugin-commonjs": {
+          "version": "9.1.3",
+          "bundled": true,
+          "requires": {
+            "estree-walker": "^0.5.1",
+            "magic-string": "^0.22.4",
+            "resolve": "^1.5.0",
+            "rollup-pluginutils": "^2.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "estree-walker": {
+              "version": "0.5.2",
+              "bundled": true
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "rollup-pluginutils": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "estree-walker": "^0.5.2",
+                "micromatch": "^2.3.11"
+              }
+            }
+          }
+        },
+        "rollup-plugin-node-resolve": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "^2.0.0",
+            "is-module": "^1.0.0",
+            "resolve": "^1.1.6"
+          },
+          "dependencies": {
+            "builtin-modules": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "rollup-plugin-replace": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "magic-string": "^0.22.4",
+            "minimatch": "^3.0.2",
+            "rollup-pluginutils": "^2.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "estree-walker": {
+              "version": "0.5.2",
+              "bundled": true
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "rollup-pluginutils": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "estree-walker": "^0.5.2",
+                "micromatch": "^2.3.11"
+              }
+            }
+          }
+        },
+        "rollup-plugin-uglify": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0-beta.47",
+            "uglify-js": "^3.3.25"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.0.0-beta.49",
+              "bundled": true,
+              "requires": {
+                "@babel/highlight": "7.0.0-beta.49"
+              }
+            },
+            "@babel/highlight": {
+              "version": "7.0.0-beta.49",
+              "bundled": true,
+              "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
+              }
+            },
+            "commander": {
+              "version": "2.15.1",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "3.4.0",
+              "bundled": true,
+              "requires": {
+                "commander": "~2.15.0",
+                "source-map": "~0.6.1"
+              }
+            }
+          }
+        },
+        "rollup-pluginutils": {
+          "version": "1.5.2",
+          "bundled": true,
+          "requires": {
+            "estree-walker": "^0.2.1",
+            "minimatch": "^3.0.2"
+          }
+        },
+        "rst-selector-parser": {
+          "version": "2.2.3",
+          "bundled": true,
+          "requires": {
+            "lodash.flattendeep": "^4.4.0",
+            "nearley": "^2.7.10"
+          }
+        },
+        "rsvp": {
+          "version": "3.6.2",
+          "bundled": true
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "run-queue": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.1.1"
+          }
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "rx-lite-aggregates": {
+          "version": "4.0.8",
+          "bundled": true,
+          "requires": {
+            "rx-lite": "*"
+          }
+        },
+        "rxjs": {
+          "version": "5.5.11",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "sane": {
+          "version": "2.5.2",
+          "bundled": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "capture-exit": "^1.2.0",
+            "exec-sh": "^0.2.0",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^1.2.3",
+            "micromatch": "^3.1.4",
+            "minimist": "^1.1.1",
+            "walker": "~1.0.5",
+            "watch": "~0.18.0"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true
+                },
+                "aproba": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "delegates": "^1.0.0",
+                    "readable-stream": "^2.0.6"
+                  }
+                },
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "^1.0.0",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "chownr": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "debug": {
+                  "version": "2.6.9",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "deep-extend": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "detect-libc": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "optional": true
+                },
+                "fs-minipass": {
+                  "version": "1.2.5",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "minipass": "^2.2.1"
+                  }
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "aproba": "^1.0.3",
+                    "console-control-strings": "^1.0.0",
+                    "has-unicode": "^2.0.0",
+                    "object-assign": "^4.1.0",
+                    "signal-exit": "^3.0.0",
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wide-align": "^1.1.0"
+                  }
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.4",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
+                  }
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "iconv-lite": {
+                  "version": "0.4.21",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "safer-buffer": "^2.1.0"
+                  }
+                },
+                "ignore-walk": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "minimatch": "^3.0.4"
+                  }
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "once": "^1.3.0",
+                    "wrappy": "1"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true
+                },
+                "ini": {
+                  "version": "1.3.5",
+                  "bundled": true,
+                  "optional": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "^1.0.0"
+                  }
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "^1.1.7"
+                  }
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                },
+                "minipass": {
+                  "version": "2.2.4",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "^5.1.1",
+                    "yallist": "^3.0.0"
+                  }
+                },
+                "minizlib": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "minipass": "^2.2.1"
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "needle": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "debug": "^2.1.2",
+                    "iconv-lite": "^0.4.4",
+                    "sax": "^1.2.4"
+                  }
+                },
+                "node-pre-gyp": {
+                  "version": "0.10.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "detect-libc": "^1.0.2",
+                    "mkdirp": "^0.5.1",
+                    "needle": "^2.2.0",
+                    "nopt": "^4.0.1",
+                    "npm-packlist": "^1.1.6",
+                    "npmlog": "^4.0.2",
+                    "rc": "^1.1.7",
+                    "rimraf": "^2.6.1",
+                    "semver": "^5.3.0",
+                    "tar": "^4"
+                  }
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "abbrev": "1",
+                    "osenv": "^0.1.4"
+                  }
+                },
+                "npm-bundled": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "optional": true
+                },
+                "npm-packlist": {
+                  "version": "1.1.10",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "ignore-walk": "^3.0.1",
+                    "npm-bundled": "^1.0.1"
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "are-we-there-yet": "~1.1.2",
+                    "console-control-strings": "~1.1.0",
+                    "gauge": "~2.7.3",
+                    "set-blocking": "~2.0.0"
+                  }
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "wrappy": "1"
+                  }
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "osenv": {
+                  "version": "0.1.5",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "os-homedir": "^1.0.0",
+                    "os-tmpdir": "^1.0.0"
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "process-nextick-args": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "rc": {
+                  "version": "1.2.7",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "deep-extend": "^0.5.1",
+                    "ini": "~1.3.0",
+                    "minimist": "^1.2.0",
+                    "strip-json-comments": "~2.0.1"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.3.6",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.3",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~2.0.0",
+                    "safe-buffer": "~5.1.1",
+                    "string_decoder": "~1.1.1",
+                    "util-deprecate": "~1.0.1"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "glob": "^7.0.5"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "bundled": true
+                },
+                "safer-buffer": {
+                  "version": "2.1.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "sax": {
+                  "version": "1.2.4",
+                  "bundled": true,
+                  "optional": true
+                },
+                "semver": {
+                  "version": "5.5.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "optional": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "safe-buffer": "~5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  }
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "optional": true
+                },
+                "tar": {
+                  "version": "4.4.1",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "chownr": "^1.0.1",
+                    "fs-minipass": "^1.2.5",
+                    "minipass": "^2.2.4",
+                    "minizlib": "^1.1.0",
+                    "mkdirp": "^0.5.0",
+                    "safe-buffer": "^5.1.1",
+                    "yallist": "^3.0.2"
+                  }
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "optional": true
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "string-width": "^1.0.2"
+                  }
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "yallist": {
+                  "version": "3.0.2",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "schema-utils": {
+          "version": "0.4.5",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "scoped-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "select-hose": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "selfsigned": {
+          "version": "1.10.3",
+          "bundled": true,
+          "requires": {
+            "node-forge": "0.7.5"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "send": {
+          "version": "0.16.2",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "serialize-javascript": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "serve-index": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.4",
+            "batch": "0.6.1",
+            "debug": "2.6.9",
+            "escape-html": "~1.0.3",
+            "http-errors": "~1.6.2",
+            "mime-types": "~2.1.17",
+            "parseurl": "~1.3.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.13.2",
+          "bundled": true,
+          "requires": {
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
+            "send": "0.16.2"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "sha.js": {
+          "version": "2.4.11",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          }
+        },
+        "shellwords": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "sockjs": {
+          "version": "0.3.19",
+          "bundled": true,
+          "requires": {
+            "faye-websocket": "^0.10.0",
+            "uuid": "^3.0.1"
+          }
+        },
+        "sockjs-client": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.6",
+            "eventsource": "0.1.6",
+            "faye-websocket": "~0.11.0",
+            "inherits": "^2.0.1",
+            "json3": "^3.3.2",
+            "url-parse": "^1.1.8"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "faye-websocket": {
+              "version": "0.11.1",
+              "bundled": true,
+              "requires": {
+                "websocket-driver": ">=0.5.1"
+              }
+            }
+          }
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
+        "source-list-map": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "atob": "^2.0.0",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "bundled": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "spdy": {
+          "version": "3.4.7",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "handle-thing": "^1.2.5",
+            "http-deceiver": "^1.2.7",
+            "safe-buffer": "^5.0.1",
+            "select-hose": "^2.0.0",
+            "spdy-transport": "^2.0.18"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "spdy-transport": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "detect-node": "^2.0.3",
+            "hpack.js": "^2.1.6",
+            "obuf": "^1.1.1",
+            "readable-stream": "^2.2.9",
+            "safe-buffer": "^5.0.1",
+            "wbuf": "^1.7.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "ssri": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "stack-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "stream-browserify": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "stream-each": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "stream-http": {
+          "version": "2.8.2",
+          "bundled": true,
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "string-length": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "astral-regex": "^1.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "string-template": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-bom-stream": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "first-chunk-stream": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "bundled": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "table": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "ajv": "^5.2.3",
+            "ajv-keywords": "^2.1.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "bundled": true,
+              "requires": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+              }
+            },
+            "ajv-keywords": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "slice-ansi": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0"
+              }
+            }
+          }
+        },
+        "tapable": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "temp": {
+          "version": "0.8.3",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "bundled": true
+            }
+          }
+        },
+        "test-exclude": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "micromatch": "^3.1.8",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "textextensions": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "throat": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          }
+        },
+        "thunky": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "timers-browserify": {
+          "version": "2.0.10",
+          "bundled": true,
+          "requires": {
+            "setimmediate": "^1.0.4"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "tmpl": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "to-arraybuffer": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "bundled": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "tslib": {
+          "version": "1.9.1",
+          "bundled": true
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-is": {
+          "version": "1.6.16",
+          "bundled": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.18"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.17",
+          "bundled": true
+        },
+        "uglify-es": {
+          "version": "3.3.9",
+          "bundled": true,
+          "requires": {
+            "commander": "~2.13.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "cacache": "^10.0.4",
+            "find-cache-dir": "^1.0.0",
+            "schema-utils": "^0.4.5",
+            "serialize-javascript": "^1.4.0",
+            "source-map": "^0.6.1",
+            "uglify-es": "^3.3.4",
+            "webpack-sources": "^1.1.0",
+            "worker-farm": "^1.5.2"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "unique-filename": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "unique-slug": "^2.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true
+            }
+          }
+        },
+        "untildify": {
+          "version": "3.0.3",
+          "bundled": true
+        },
+        "upath": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "uri-js": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "url": {
+          "version": "0.11.0",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "bundled": true
+            }
+          }
+        },
+        "url-join": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "url-parse": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "querystringify": "^2.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        },
+        "url-to-options": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "urlgrey": {
+          "version": "0.4.4",
+          "bundled": true
+        },
+        "use": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^6.0.2"
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.1"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "util.promisify": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "v8-compile-cache": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "v8flags": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "user-home": "^1.1.1"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "vary": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        },
+        "vinyl-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.3.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0",
+            "strip-bom-stream": "^2.0.0",
+            "vinyl": "^1.1.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "vlq": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "bundled": true,
+          "requires": {
+            "indexof": "0.0.1"
+          }
+        },
+        "w3c-hr-time": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browser-process-hrtime": "^0.1.2"
+          }
+        },
+        "walker": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "makeerror": "1.0.x"
+          }
+        },
+        "watch": {
+          "version": "0.18.0",
+          "bundled": true,
+          "requires": {
+            "exec-sh": "^0.2.0",
+            "minimist": "^1.2.0"
+          }
+        },
+        "watchpack": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "chokidar": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "neo-async": "^2.5.0"
+          }
+        },
+        "wbuf": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "webassemblyjs": {
+          "version": "1.4.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/validation": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "@webassemblyjs/wast-parser": "1.4.3",
+            "long": "^3.2.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "webpack": {
+          "version": "4.8.3",
+          "bundled": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.4.3",
+            "@webassemblyjs/wasm-edit": "1.4.3",
+            "@webassemblyjs/wasm-parser": "1.4.3",
+            "acorn": "^5.0.0",
+            "acorn-dynamic-import": "^3.0.0",
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0",
+            "chrome-trace-event": "^0.1.1",
+            "enhanced-resolve": "^4.0.0",
+            "eslint-scope": "^3.7.1",
+            "loader-runner": "^2.3.0",
+            "loader-utils": "^1.1.0",
+            "memory-fs": "~0.4.1",
+            "micromatch": "^3.1.8",
+            "mkdirp": "~0.5.0",
+            "neo-async": "^2.5.0",
+            "node-libs-browser": "^2.0.0",
+            "schema-utils": "^0.4.4",
+            "tapable": "^1.0.0",
+            "uglifyjs-webpack-plugin": "^1.2.4",
+            "watchpack": "^1.5.0",
+            "webpack-sources": "^1.0.1"
+          }
+        },
+        "webpack-addons": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "jscodeshift": "^0.4.0"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.0.1"
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "ast-types": {
+              "version": "0.10.1",
+              "bundled": true
+            },
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "requires": {
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "requires": {
+                "is-posix-bracket": "^0.1.0"
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^1.0.0"
+              }
+            },
+            "jscodeshift": {
+              "version": "0.4.1",
+              "bundled": true,
+              "requires": {
+                "async": "^1.5.0",
+                "babel-plugin-transform-flow-strip-types": "^6.8.0",
+                "babel-preset-es2015": "^6.9.0",
+                "babel-preset-stage-1": "^6.5.0",
+                "babel-register": "^6.9.0",
+                "babylon": "^6.17.3",
+                "colors": "^1.1.2",
+                "flow-parser": "^0.*",
+                "lodash": "^4.13.1",
+                "micromatch": "^2.3.7",
+                "node-dir": "0.1.8",
+                "nomnom": "^1.8.1",
+                "recast": "^0.12.5",
+                "temp": "^0.8.1",
+                "write-file-atomic": "^1.2.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
+              }
+            },
+            "recast": {
+              "version": "0.12.9",
+              "bundled": true,
+              "requires": {
+                "ast-types": "0.10.1",
+                "core-js": "^2.4.1",
+                "esprima": "~4.0.0",
+                "private": "~0.1.5",
+                "source-map": "~0.6.1"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "webpack-cli": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "cross-spawn": "^6.0.5",
+            "diff": "^3.5.0",
+            "enhanced-resolve": "^4.0.0",
+            "envinfo": "^5.7.0",
+            "glob-all": "^3.1.0",
+            "global-modules": "^1.0.0",
+            "got": "^8.3.1",
+            "import-local": "^1.0.0",
+            "inquirer": "^5.2.0",
+            "interpret": "^1.1.0",
+            "jscodeshift": "^0.5.0",
+            "listr": "^0.14.1",
+            "loader-utils": "^1.1.0",
+            "lodash": "^4.17.10",
+            "log-symbols": "^2.2.0",
+            "mkdirp": "^0.5.1",
+            "p-each-series": "^1.0.0",
+            "p-lazy": "^1.0.0",
+            "prettier": "^1.12.1",
+            "supports-color": "^5.4.0",
+            "v8-compile-cache": "^2.0.0",
+            "webpack-addons": "^1.1.5",
+            "yargs": "^11.1.0",
+            "yeoman-environment": "^2.1.1",
+            "yeoman-generator": "^2.0.5"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.1",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "supports-color": {
+              "version": "5.4.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "webpack-dev-middleware": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "loud-rejection": "^1.6.0",
+            "memory-fs": "~0.4.1",
+            "mime": "^2.1.0",
+            "path-is-absolute": "^1.0.0",
+            "range-parser": "^1.0.3",
+            "url-join": "^4.0.0",
+            "webpack-log": "^1.0.1"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "2.3.1",
+              "bundled": true
+            }
+          }
+        },
+        "webpack-dev-server": {
+          "version": "3.1.4",
+          "bundled": true,
+          "requires": {
+            "ansi-html": "0.0.7",
+            "array-includes": "^3.0.3",
+            "bonjour": "^3.5.0",
+            "chokidar": "^2.0.0",
+            "compression": "^1.5.2",
+            "connect-history-api-fallback": "^1.3.0",
+            "debug": "^3.1.0",
+            "del": "^3.0.0",
+            "express": "^4.16.2",
+            "html-entities": "^1.2.0",
+            "http-proxy-middleware": "~0.18.0",
+            "import-local": "^1.0.0",
+            "internal-ip": "1.2.0",
+            "ip": "^1.1.5",
+            "killable": "^1.0.0",
+            "loglevel": "^1.4.1",
+            "opn": "^5.1.0",
+            "portfinder": "^1.0.9",
+            "selfsigned": "^1.9.1",
+            "serve-index": "^1.7.2",
+            "sockjs": "0.3.19",
+            "sockjs-client": "1.1.4",
+            "spdy": "^3.4.1",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^5.1.0",
+            "webpack-dev-middleware": "3.1.3",
+            "webpack-log": "^1.1.2",
+            "yargs": "11.0.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "11.0.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
+              }
+            }
+          }
+        },
+        "webpack-log": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.1.0",
+            "log-symbols": "^2.1.0",
+            "loglevelnext": "^1.0.1",
+            "uuid": "^3.1.0"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "websocket-driver": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "http-parser-js": ">=0.4.0",
+            "websocket-extensions": ">=0.1.1"
+          }
+        },
+        "websocket-extensions": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.19"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "whatwg-mimetype": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "6.4.1",
+          "bundled": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "worker-farm": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "errno": "~0.1.7"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
+        },
+        "ws": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        },
+        "yeoman-environment": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "diff": "^3.3.1",
+            "escape-string-regexp": "^1.0.2",
+            "globby": "^8.0.1",
+            "grouped-queue": "^0.3.3",
+            "inquirer": "^5.2.0",
+            "is-scoped": "^1.0.0",
+            "lodash": "^4.17.10",
+            "log-symbols": "^2.1.0",
+            "mem-fs": "^1.1.0",
+            "strip-ansi": "^4.0.0",
+            "text-table": "^0.2.0",
+            "untildify": "^3.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "async": "^2.6.0",
+            "chalk": "^2.3.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^6.0.5",
+            "dargs": "^5.1.0",
+            "dateformat": "^3.0.3",
+            "debug": "^3.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^2.1.0",
+            "github-username": "^4.0.0",
+            "istextorbinary": "^2.2.1",
+            "lodash": "^4.17.10",
+            "make-dir": "^1.1.0",
+            "mem-fs-editor": "^4.0.0",
+            "minimist": "^1.2.0",
+            "pretty-bytes": "^4.0.2",
+            "read-chunk": "^2.1.0",
+            "read-pkg-up": "^3.0.0",
+            "rimraf": "^2.6.2",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.8.0",
+            "text-table": "^0.2.0",
+            "through2": "^2.0.0",
+            "yeoman-environment": "^2.0.5"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "lodash": "^4.17.10"
+              }
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        }
+      }
     },
     "fs-extra": {
       "version": "3.0.1",
@@ -4667,6 +15910,11 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+      "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -4730,6 +15978,41 @@
         "param-case": "2.1.x",
         "relateurl": "0.2.x",
         "uglify-js": "3.3.x"
+      }
+    },
+    "html-to-react": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.3.tgz",
+      "integrity": "sha512-4Qi5/t8oBr6c1t1kBJKyxEeJu0lb7ctvq29oFZioiUHH0Wz88VWGwoXuH26HDt9v64bDHA4NMPNTH8bVrcaJWA==",
+      "requires": {
+        "domhandler": "^2.3.0",
+        "escape-string-regexp": "^1.0.5",
+        "htmlparser2": "^3.8.3",
+        "ramda": "^0.25.0",
+        "underscore.string.fp": "^1.0.4"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        }
       }
     },
     "html-webpack-plugin": {
@@ -6421,6 +17704,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
+    "lodash-es": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -7350,6 +18638,14 @@
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -8661,6 +19957,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+    },
     "randomatic": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
@@ -8808,6 +20109,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.0.tgz",
       "integrity": "sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw=="
+    },
+    "react-redux": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "requires": {
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.0.0",
+        "lodash": "^4.17.5",
+        "lodash-es": "^4.17.5",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.0"
+      }
     },
     "react-scripts": {
       "version": "1.1.4",
@@ -8990,6 +20304,17 @@
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
         }
+      }
+    },
+    "redux": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "requires": {
+        "lodash": "^4.2.1",
+        "lodash-es": "^4.2.1",
+        "loose-envify": "^1.1.0",
+        "symbol-observable": "^1.0.3"
       }
     },
     "regenerate": {
@@ -9250,6 +20575,11 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
+    "reverse-arguments": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reverse-arguments/-/reverse-arguments-1.0.0.tgz",
+      "integrity": "sha1-woCVo6khrHFdYYNN3s6QJ5kmZ80="
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -9410,6 +20740,14 @@
         "statuses": "~1.4.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
@@ -9429,6 +20767,16 @@
         "http-errors": "~1.6.2",
         "mime-types": "~2.1.17",
         "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "serve-static": {
@@ -9559,6 +20907,14 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -9681,6 +21037,16 @@
         "inherits": "^2.0.1",
         "json3": "^3.3.2",
         "url-parse": "^1.1.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "sort-keys": {
@@ -9772,6 +21138,16 @@
         "safe-buffer": "^5.0.1",
         "select-hose": "^2.0.0",
         "spdy-transport": "^2.0.18"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "spdy-transport": {
@@ -9786,6 +21162,16 @@
         "readable-stream": "^2.2.9",
         "safe-buffer": "^5.0.1",
         "wbuf": "^1.7.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "split-string": {
@@ -10007,6 +21393,11 @@
         "path-to-regexp": "^1.0.1",
         "serviceworker-cache-polyfill": "^4.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -10311,6 +21702,22 @@
             "window-size": "0.1.0"
           }
         }
+      }
+    },
+    "underscore.string": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
+      "integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI="
+    },
+    "underscore.string.fp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/underscore.string.fp/-/underscore.string.fp-1.0.4.tgz",
+      "integrity": "sha1-BUs/GEO8rlYShsh95eiHm0/Jg2Q=",
+      "requires": {
+        "chickencurry": "1.1.1",
+        "compose-function": "^2.0.0",
+        "reverse-arguments": "1.0.0",
+        "underscore.string": "3.0.3"
       }
     },
     "union-value": {

--- a/examples/wp-rest-api/package.json
+++ b/examples/wp-rest-api/package.json
@@ -3,9 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "debug": "^3.1.0",
+    "fresh-data": "file:../../",
+    "html-to-react": "^1.3.3",
+    "qs": "^6.5.2",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
-    "react-scripts": "1.1.4"
+    "react-redux": "^5.0.7",
+    "react-scripts": "1.1.4",
+    "redux": "^3.7.2"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
This updates the package.json files to no longer require npm link for
the example code, just a good build before doing `npm install` on the
examples.

It also updates the package-lock.json files while we're at it.

To Test:
1. `npm install`
2. `npm run build`
3. `cd examples/hello-world`
4. `npm install`
5. `npm start` and ensure the app comes up.
6. `cd ../wp-rest-api`
7. `npm install`
8. `npm start` and ensure the app comes up.
