### PR TITLE
Fix timeout in waitForData

### DIFF
--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -428,6 +428,24 @@ describe( 'ApiClient', () => {
 				[ 'things', '1' ], undefined, DEFAULT_FETCH_TIMEOUT
 			) ).toThrowError();
 		} );
+
+		it( 'should call waitForData', () => {
+			const readValue = {};
+			class TestApi extends FreshDataApi {
+				static endpoints = {
+					things: {
+						read: () => ( readValue ),
+					},
+				};
+				static methods = {};
+			}
+			const api = new TestApi();
+			const apiClient = new ApiClient( api, '123' );
+
+			apiClient.waitForData = jest.fn();
+			apiClient.fetchData( [ 'things', '1' ], { param: true }, DEFAULT_FETCH_TIMEOUT );
+			expect( apiClient.waitForData ).toHaveBeenCalledWith( [ 'things', '1' ], { param: true }, readValue, DEFAULT_FETCH_TIMEOUT );
+		} );
 	} );
 
 	describe( '#waitForData', () => {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -151,7 +151,7 @@ export default class ApiClient {
 		}
 
 		const value = endpoint.read( this.methods, remainingPath, params );
-		return this.waitForData( endpointPath, params, value );
+		return this.waitForData( endpointPath, params, value, timeout );
 	}
 
 	/**


### PR DESCRIPTION
The timeout parameter was omitted for waitForData, causing the
timeoutPromise to prematurely resolve.

An extra test was added to verify the correct behavior of this code.

To Test:
1. `npm install`
2. `npm test` and ensure all tests pass.

Additional testing:
The `wp-rest-api` example can be run and the dev console before would have shown an unhandled promise rejection (the timeoutPromise). With this code, that rejection should not happen.
