### PR TITLE
Update packages and prepublishOnly script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,10 @@
 			"dev": true,
 			"requires": {
 				"@babel/types": "7.0.0-beta.44",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.2.0",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"jsesc": "2.5.1",
+				"lodash": "4.17.10",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			}
 		},
 		"@babel/helper-function-name": {
@@ -61,9 +61,9 @@
 			"integrity": "sha512-X3Ur/A/lIbbP8W0pmwgqtDXIxhQmxPaiwY9SKP7kF9wvZfjZRwMvbJE92ozUhF3UDK3DCKaV7oGqmI1rP/zqWA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
+				"chalk": "2.3.2",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			}
 		},
 		"@babel/template": {
@@ -75,7 +75,7 @@
 				"@babel/code-frame": "7.0.0-beta.44",
 				"@babel/types": "7.0.0-beta.44",
 				"babylon": "7.0.0-beta.44",
-				"lodash": "^4.2.0"
+				"lodash": "4.17.10"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -93,9 +93,9 @@
 					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
+						"chalk": "2.3.2",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				}
 			}
@@ -112,10 +112,10 @@
 				"@babel/helper-split-export-declaration": "7.0.0-beta.44",
 				"@babel/types": "7.0.0-beta.44",
 				"babylon": "7.0.0-beta.44",
-				"debug": "^3.1.0",
-				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.2.0"
+				"debug": "3.1.0",
+				"globals": "11.5.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.10"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -133,9 +133,9 @@
 					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
+						"chalk": "2.3.2",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				},
 				"globals": {
@@ -152,9 +152,9 @@
 			"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.2.0",
-				"to-fast-properties": "^2.0.0"
+				"esutils": "2.0.2",
+				"lodash": "4.17.10",
+				"to-fast-properties": "2.0.0"
 			},
 			"dependencies": {
 				"to-fast-properties": {
@@ -171,8 +171,8 @@
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
 			"dev": true,
 			"requires": {
-				"call-me-maybe": "^1.0.1",
-				"glob-to-regexp": "^0.3.0"
+				"call-me-maybe": "1.0.1",
+				"glob-to-regexp": "0.3.0"
 			}
 		},
 		"@nodelib/fs.stat": {
@@ -187,7 +187,7 @@
 			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
 			"dev": true,
 			"requires": {
-				"any-observable": "^0.3.0"
+				"any-observable": "0.3.0"
 			}
 		},
 		"@sindresorhus/is": {
@@ -216,7 +216,7 @@
 			"requires": {
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
-				"debug": "^3.1.0",
+				"debug": "3.1.0",
 				"webassemblyjs": "1.4.3"
 			}
 		},
@@ -232,7 +232,7 @@
 			"integrity": "sha512-e8+KZHh+RV8MUvoSRtuT1sFXskFnWG9vbDy47Oa166xX+l0dD5sERJ21g5/tcH8Yo95e9IN3u7Jc3NbhnUcSkw==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0"
+				"debug": "3.1.0"
 			}
 		},
 		"@webassemblyjs/helper-code-frame": {
@@ -266,7 +266,7 @@
 				"@webassemblyjs/helper-buffer": "1.4.3",
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
 				"@webassemblyjs/wasm-gen": "1.4.3",
-				"debug": "^3.1.0"
+				"debug": "3.1.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
@@ -275,7 +275,7 @@
 			"integrity": "sha512-4u0LJLSPzuRDWHwdqsrThYn+WqMFVqbI2ltNrHvZZkzFPO8XOZ0HFQ5eVc4jY/TNHgXcnwrHjONhPGYuuf//KQ==",
 			"dev": true,
 			"requires": {
-				"leb": "^0.3.0"
+				"leb": "0.3.0"
 			}
 		},
 		"@webassemblyjs/validation": {
@@ -301,7 +301,7 @@
 				"@webassemblyjs/wasm-opt": "1.4.3",
 				"@webassemblyjs/wasm-parser": "1.4.3",
 				"@webassemblyjs/wast-printer": "1.4.3",
-				"debug": "^3.1.0"
+				"debug": "3.1.0"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
@@ -325,7 +325,7 @@
 				"@webassemblyjs/helper-buffer": "1.4.3",
 				"@webassemblyjs/wasm-gen": "1.4.3",
 				"@webassemblyjs/wasm-parser": "1.4.3",
-				"debug": "^3.1.0"
+				"debug": "3.1.0"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
@@ -351,7 +351,7 @@
 				"@webassemblyjs/floating-point-hex-parser": "1.4.3",
 				"@webassemblyjs/helper-code-frame": "1.4.3",
 				"@webassemblyjs/helper-fsm": "1.4.3",
-				"long": "^3.2.0",
+				"long": "3.2.0",
 				"webassemblyjs": "1.4.3"
 			}
 		},
@@ -363,7 +363,7 @@
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
-				"long": "^3.2.0"
+				"long": "3.2.0"
 			}
 		},
 		"abab": {
@@ -378,7 +378,7 @@
 			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 			"dev": true,
 			"requires": {
-				"mime-types": "~2.1.18",
+				"mime-types": "2.1.18",
 				"negotiator": "0.6.1"
 			}
 		},
@@ -394,7 +394,7 @@
 			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.0"
+				"acorn": "5.5.3"
 			}
 		},
 		"acorn-globals": {
@@ -403,7 +403,7 @@
 			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.0.0"
+				"acorn": "5.5.3"
 			}
 		},
 		"acorn-jsx": {
@@ -412,7 +412,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "^3.0.4"
+				"acorn": "3.3.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -429,10 +429,10 @@
 			"integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
 			"dev": true,
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0",
-				"uri-js": "^4.2.1"
+				"fast-deep-equal": "2.0.1",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1",
+				"uri-js": "4.2.1"
 			},
 			"dependencies": {
 				"fast-deep-equal": {
@@ -455,9 +455,9 @@
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2",
-				"longest": "^1.0.1",
-				"repeat-string": "^1.5.2"
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -466,7 +466,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -501,7 +501,7 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "1.9.1"
 			}
 		},
 		"any-observable": {
@@ -516,8 +516,8 @@
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"micromatch": "3.1.9",
+				"normalize-path": "2.1.1"
 			}
 		},
 		"append-transform": {
@@ -526,7 +526,7 @@
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "^1.0.0"
+				"default-require-extensions": "1.0.0"
 			}
 		},
 		"aproba": {
@@ -541,7 +541,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"argv": {
@@ -557,7 +557,7 @@
 			"dev": true,
 			"requires": {
 				"ast-types-flow": "0.0.7",
-				"commander": "^2.11.0"
+				"commander": "2.13.0"
 			}
 		},
 		"arr-diff": {
@@ -608,8 +608,8 @@
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0"
 			}
 		},
 		"array-union": {
@@ -618,7 +618,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "^1.0.1"
+				"array-uniq": "1.0.3"
 			}
 		},
 		"array-uniq": {
@@ -656,9 +656,9 @@
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"bn.js": "4.11.8",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"assert": {
@@ -757,21 +757,21 @@
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-polyfill": "^6.26.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"chokidar": "^1.6.1",
-				"commander": "^2.11.0",
-				"convert-source-map": "^1.5.0",
-				"fs-readdir-recursive": "^1.0.0",
-				"glob": "^7.1.2",
-				"lodash": "^4.17.4",
-				"output-file-sync": "^1.1.2",
-				"path-is-absolute": "^1.0.1",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.6",
-				"v8flags": "^2.1.1"
+				"babel-core": "6.26.3",
+				"babel-polyfill": "6.26.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"chokidar": "1.7.0",
+				"commander": "2.13.0",
+				"convert-source-map": "1.5.1",
+				"fs-readdir-recursive": "1.1.0",
+				"glob": "7.1.2",
+				"lodash": "4.17.10",
+				"output-file-sync": "1.1.2",
+				"path-is-absolute": "1.0.1",
+				"slash": "1.0.0",
+				"source-map": "0.5.7",
+				"v8flags": "2.1.1"
 			},
 			"dependencies": {
 				"anymatch": {
@@ -781,8 +781,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"micromatch": "^2.1.5",
-						"normalize-path": "^2.0.0"
+						"micromatch": "2.3.11",
+						"normalize-path": "2.1.1"
 					}
 				},
 				"arr-diff": {
@@ -792,7 +792,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -809,9 +809,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"chokidar": {
@@ -821,15 +821,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"anymatch": "^1.3.0",
-						"async-each": "^1.0.0",
-						"fsevents": "^1.0.0",
-						"glob-parent": "^2.0.0",
-						"inherits": "^2.0.1",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^2.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.0.0"
+						"anymatch": "1.3.2",
+						"async-each": "1.0.1",
+						"fsevents": "1.2.4",
+						"glob-parent": "2.0.0",
+						"inherits": "2.0.3",
+						"is-binary-path": "1.0.1",
+						"is-glob": "2.0.1",
+						"path-is-absolute": "1.0.1",
+						"readdirp": "2.1.0"
 					}
 				},
 				"expand-brackets": {
@@ -839,7 +839,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -849,7 +849,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"glob-parent": {
@@ -859,7 +859,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"is-glob": "^2.0.0"
+						"is-glob": "2.0.1"
 					}
 				},
 				"is-extglob": {
@@ -874,7 +874,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -884,7 +884,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -894,19 +894,19 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				}
 			}
@@ -917,9 +917,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -934,11 +934,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"supports-color": {
@@ -955,25 +955,25 @@
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"babylon": {
@@ -1003,8 +1003,8 @@
 				"@babel/traverse": "7.0.0-beta.44",
 				"@babel/types": "7.0.0-beta.44",
 				"babylon": "7.0.0-beta.44",
-				"eslint-scope": "~3.7.1",
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -1022,9 +1022,9 @@
 					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
+						"chalk": "2.3.2",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				}
 			}
@@ -1035,14 +1035,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.10",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -1059,9 +1059,9 @@
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1070,9 +1070,9 @@
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-assignable-expression": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
@@ -1081,9 +1081,9 @@
 			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"esutils": "^2.0.2"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"esutils": "2.0.2"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -1092,10 +1092,10 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-define-map": {
@@ -1104,10 +1104,10 @@
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -1116,9 +1116,9 @@
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-explode-class": {
@@ -1127,10 +1127,10 @@
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
 			"dev": true,
 			"requires": {
-				"babel-helper-bindify-decorators": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-bindify-decorators": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-function-name": {
@@ -1139,11 +1139,11 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"dev": true,
 			"requires": {
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -1152,8 +1152,8 @@
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -1162,8 +1162,8 @@
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -1172,8 +1172,8 @@
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-regex": {
@@ -1182,9 +1182,9 @@
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -1193,11 +1193,11 @@
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -1206,12 +1206,12 @@
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"dev": true,
 			"requires": {
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helpers": {
@@ -1220,8 +1220,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-jest": {
@@ -1230,8 +1230,8 @@
 			"integrity": "sha1-u6079SP7IC2gXtCmVAtIyE7tE6Y=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.6",
-				"babel-preset-jest": "^23.0.1"
+				"babel-plugin-istanbul": "4.1.6",
+				"babel-preset-jest": "23.0.1"
 			}
 		},
 		"babel-loader": {
@@ -1240,9 +1240,9 @@
 			"integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "^1.0.0",
-				"loader-utils": "^1.0.2",
-				"mkdirp": "^0.5.1"
+				"find-cache-dir": "1.0.0",
+				"loader-utils": "1.1.0",
+				"mkdirp": "0.5.1"
 			}
 		},
 		"babel-messages": {
@@ -1251,7 +1251,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -1260,7 +1260,7 @@
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-external-helpers": {
@@ -1269,7 +1269,7 @@
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -1278,10 +1278,10 @@
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"find-up": "^2.1.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"test-exclude": "^4.2.1"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"test-exclude": "4.2.1"
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -1368,9 +1368,9 @@
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-generators": "^6.5.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-generators": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-async-to-generator": {
@@ -1379,9 +1379,9 @@
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"dev": true,
 			"requires": {
-				"babel-helper-remap-async-to-generator": "^6.24.1",
-				"babel-plugin-syntax-async-functions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-class-constructor-call": {
@@ -1390,9 +1390,9 @@
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-syntax-class-constructor-call": "6.18.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -1401,10 +1401,10 @@
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-plugin-syntax-class-properties": "^6.8.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-plugin-syntax-class-properties": "6.13.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-decorators": {
@@ -1413,11 +1413,11 @@
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
 			"dev": true,
 			"requires": {
-				"babel-helper-explode-class": "^6.24.1",
-				"babel-plugin-syntax-decorators": "^6.13.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-explode-class": "6.24.1",
+				"babel-plugin-syntax-decorators": "6.13.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -1426,7 +1426,7 @@
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1435,7 +1435,7 @@
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -1444,11 +1444,11 @@
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.10"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -1457,15 +1457,15 @@
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"dev": true,
 			"requires": {
-				"babel-helper-define-map": "^6.24.1",
-				"babel-helper-function-name": "^6.24.1",
-				"babel-helper-optimise-call-expression": "^6.24.1",
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-define-map": "6.26.0",
+				"babel-helper-function-name": "6.24.1",
+				"babel-helper-optimise-call-expression": "6.24.1",
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -1474,8 +1474,8 @@
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -1484,7 +1484,7 @@
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -1493,8 +1493,8 @@
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -1503,7 +1503,7 @@
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -1512,9 +1512,9 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"dev": true,
 			"requires": {
-				"babel-helper-function-name": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -1523,7 +1523,7 @@
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -1532,9 +1532,9 @@
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -1543,10 +1543,10 @@
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -1555,9 +1555,9 @@
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-hoist-variables": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -1566,9 +1566,9 @@
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -1577,8 +1577,8 @@
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"dev": true,
 			"requires": {
-				"babel-helper-replace-supers": "^6.24.1",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-replace-supers": "6.24.1",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -1587,12 +1587,12 @@
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"dev": true,
 			"requires": {
-				"babel-helper-call-delegate": "^6.24.1",
-				"babel-helper-get-function-arity": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1",
-				"babel-traverse": "^6.24.1",
-				"babel-types": "^6.24.1"
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -1601,8 +1601,8 @@
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -1611,7 +1611,7 @@
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -1620,9 +1620,9 @@
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -1631,7 +1631,7 @@
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -1640,7 +1640,7 @@
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -1649,9 +1649,9 @@
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"dev": true,
 			"requires": {
-				"babel-helper-regex": "^6.24.1",
-				"babel-runtime": "^6.22.0",
-				"regexpu-core": "^2.0.0"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1660,9 +1660,9 @@
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-export-extensions": {
@@ -1671,8 +1671,8 @@
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-export-extensions": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-export-extensions": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1681,8 +1681,8 @@
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-flow": "^6.18.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-flow": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1691,8 +1691,8 @@
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-				"babel-runtime": "^6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
@@ -1701,7 +1701,7 @@
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -1710,9 +1710,9 @@
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"dev": true,
 			"requires": {
-				"babel-helper-builder-react-jsx": "^6.24.1",
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-helper-builder-react-jsx": "6.26.0",
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-self": {
@@ -1721,8 +1721,8 @@
 			"integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
@@ -1731,8 +1731,8 @@
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.8.0",
-				"babel-runtime": "^6.22.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -1741,7 +1741,7 @@
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"dev": true,
 			"requires": {
-				"regenerator-transform": "^0.10.0"
+				"regenerator-transform": "0.10.1"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -1750,8 +1750,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-polyfill": {
@@ -1760,9 +1760,9 @@
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"regenerator-runtime": "^0.10.5"
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.10.5"
 			},
 			"dependencies": {
 				"regenerator-runtime": {
@@ -1779,36 +1779,36 @@
 			"integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-to-generator": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-				"babel-plugin-transform-es2015-classes": "^6.23.0",
-				"babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-				"babel-plugin-transform-es2015-for-of": "^6.23.0",
-				"babel-plugin-transform-es2015-function-name": "^6.22.0",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-				"babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-				"babel-plugin-transform-es2015-object-super": "^6.22.0",
-				"babel-plugin-transform-es2015-parameters": "^6.23.0",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-				"babel-plugin-transform-exponentiation-operator": "^6.22.0",
-				"babel-plugin-transform-regenerator": "^6.22.0",
-				"browserslist": "^3.2.6",
-				"invariant": "^2.2.2",
-				"semver": "^5.3.0"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.26.0",
+				"browserslist": "3.2.8",
+				"invariant": "2.2.4",
+				"semver": "5.5.0"
 			}
 		},
 		"babel-preset-es2015": {
@@ -1817,30 +1817,30 @@
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-check-es2015-constants": "^6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-				"babel-plugin-transform-es2015-classes": "^6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-				"babel-plugin-transform-es2015-for-of": "^6.22.0",
-				"babel-plugin-transform-es2015-function-name": "^6.24.1",
-				"babel-plugin-transform-es2015-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-				"babel-plugin-transform-es2015-object-super": "^6.24.1",
-				"babel-plugin-transform-es2015-parameters": "^6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-				"babel-plugin-transform-es2015-spread": "^6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-				"babel-plugin-transform-regenerator": "^6.24.1"
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+				"babel-plugin-transform-es2015-classes": "6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+				"babel-plugin-transform-es2015-for-of": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-literals": "6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
+				"babel-plugin-transform-es2015-object-super": "6.24.1",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.26.0"
 			}
 		},
 		"babel-preset-flow": {
@@ -1849,7 +1849,7 @@
 			"integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "^6.22.0"
+				"babel-plugin-transform-flow-strip-types": "6.22.0"
 			}
 		},
 		"babel-preset-jest": {
@@ -1858,8 +1858,8 @@
 			"integrity": "sha1-YxzFRcbPAhlDATvK8i9F2H/mIZg=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^23.0.1",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+				"babel-plugin-jest-hoist": "23.0.1",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
 			}
 		},
 		"babel-preset-react": {
@@ -1868,12 +1868,12 @@
 			"integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-jsx": "^6.3.13",
-				"babel-plugin-transform-react-display-name": "^6.23.0",
-				"babel-plugin-transform-react-jsx": "^6.24.1",
-				"babel-plugin-transform-react-jsx-self": "^6.22.0",
-				"babel-plugin-transform-react-jsx-source": "^6.22.0",
-				"babel-preset-flow": "^6.23.0"
+				"babel-plugin-syntax-jsx": "6.18.0",
+				"babel-plugin-transform-react-display-name": "6.25.0",
+				"babel-plugin-transform-react-jsx": "6.24.1",
+				"babel-plugin-transform-react-jsx-self": "6.22.0",
+				"babel-plugin-transform-react-jsx-source": "6.22.0",
+				"babel-preset-flow": "6.23.0"
 			}
 		},
 		"babel-preset-stage-1": {
@@ -1882,9 +1882,9 @@
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-class-constructor-call": "^6.24.1",
-				"babel-plugin-transform-export-extensions": "^6.22.0",
-				"babel-preset-stage-2": "^6.24.1"
+				"babel-plugin-transform-class-constructor-call": "6.24.1",
+				"babel-plugin-transform-export-extensions": "6.22.0",
+				"babel-preset-stage-2": "6.24.1"
 			}
 		},
 		"babel-preset-stage-2": {
@@ -1893,10 +1893,10 @@
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "^6.18.0",
-				"babel-plugin-transform-class-properties": "^6.24.1",
-				"babel-plugin-transform-decorators": "^6.24.1",
-				"babel-preset-stage-3": "^6.24.1"
+				"babel-plugin-syntax-dynamic-import": "6.18.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
+				"babel-plugin-transform-decorators": "6.24.1",
+				"babel-preset-stage-3": "6.24.1"
 			}
 		},
 		"babel-preset-stage-3": {
@@ -1905,11 +1905,11 @@
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-				"babel-plugin-transform-async-generator-functions": "^6.24.1",
-				"babel-plugin-transform-async-to-generator": "^6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "^6.24.1",
-				"babel-plugin-transform-object-rest-spread": "^6.22.0"
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-generator-functions": "6.24.1",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"babel-plugin-transform-object-rest-spread": "6.26.0"
 			}
 		},
 		"babel-register": {
@@ -1918,13 +1918,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.3",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.3",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.10",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
 			}
 		},
 		"babel-runtime": {
@@ -1933,8 +1933,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.3",
+				"regenerator-runtime": "0.11.1"
 			}
 		},
 		"babel-template": {
@@ -1943,11 +1943,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.10"
 			},
 			"dependencies": {
 				"babylon": {
@@ -1964,15 +1964,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.10"
 			},
 			"dependencies": {
 				"babylon": {
@@ -1998,10 +1998,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.10",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
@@ -2022,13 +2022,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2037,7 +2037,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				}
 			}
@@ -2061,7 +2061,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"big.js": {
@@ -2101,15 +2101,15 @@
 			"dev": true,
 			"requires": {
 				"bytes": "3.0.0",
-				"content-type": "~1.0.4",
+				"content-type": "1.0.4",
 				"debug": "2.6.9",
-				"depd": "~1.1.1",
-				"http-errors": "~1.6.2",
+				"depd": "1.1.2",
+				"http-errors": "1.6.3",
 				"iconv-lite": "0.4.19",
-				"on-finished": "~2.3.0",
+				"on-finished": "2.3.0",
 				"qs": "6.5.1",
 				"raw-body": "2.3.2",
-				"type-is": "~1.6.15"
+				"type-is": "1.6.16"
 			},
 			"dependencies": {
 				"debug": {
@@ -2129,12 +2129,12 @@
 			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
 			"dev": true,
 			"requires": {
-				"array-flatten": "^2.1.0",
-				"deep-equal": "^1.0.1",
-				"dns-equal": "^1.0.0",
-				"dns-txt": "^2.0.2",
-				"multicast-dns": "^6.0.1",
-				"multicast-dns-service-types": "^1.1.0"
+				"array-flatten": "2.1.1",
+				"deep-equal": "1.0.1",
+				"dns-equal": "1.0.0",
+				"dns-txt": "2.0.2",
+				"multicast-dns": "6.2.3",
+				"multicast-dns-service-types": "1.1.0"
 			}
 		},
 		"boolbase": {
@@ -2149,7 +2149,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -2159,18 +2159,18 @@
 			"integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"kind-of": "^6.0.2",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
+				"arr-flatten": "1.1.0",
+				"array-unique": "0.3.2",
+				"define-property": "1.0.0",
+				"extend-shallow": "2.0.1",
+				"fill-range": "4.0.0",
+				"isobject": "3.0.1",
+				"kind-of": "6.0.2",
+				"repeat-element": "1.1.2",
+				"snapdragon": "0.8.2",
+				"snapdragon-node": "2.1.1",
+				"split-string": "3.1.0",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2179,7 +2179,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"extend-shallow": {
@@ -2188,7 +2188,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -2228,12 +2228,12 @@
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"buffer-xor": "1.0.3",
+				"cipher-base": "1.0.4",
+				"create-hash": "1.2.0",
+				"evp_bytestokey": "1.0.3",
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"browserify-cipher": {
@@ -2242,9 +2242,9 @@
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 			"dev": true,
 			"requires": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
+				"browserify-aes": "1.2.0",
+				"browserify-des": "1.0.1",
+				"evp_bytestokey": "1.0.3"
 			}
 		},
 		"browserify-des": {
@@ -2253,9 +2253,9 @@
 			"integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1"
+				"cipher-base": "1.0.4",
+				"des.js": "1.0.0",
+				"inherits": "2.0.3"
 			}
 		},
 		"browserify-rsa": {
@@ -2264,8 +2264,8 @@
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"randombytes": "^2.0.1"
+				"bn.js": "4.11.8",
+				"randombytes": "2.0.6"
 			}
 		},
 		"browserify-sign": {
@@ -2274,13 +2274,13 @@
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.1",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.2",
-				"elliptic": "^6.0.0",
-				"inherits": "^2.0.1",
-				"parse-asn1": "^5.0.0"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"elliptic": "6.4.0",
+				"inherits": "2.0.3",
+				"parse-asn1": "5.1.1"
 			}
 		},
 		"browserify-zlib": {
@@ -2289,7 +2289,7 @@
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"dev": true,
 			"requires": {
-				"pako": "~1.0.5"
+				"pako": "1.0.6"
 			}
 		},
 		"browserslist": {
@@ -2298,8 +2298,8 @@
 			"integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000844",
-				"electron-to-chromium": "^1.3.47"
+				"caniuse-lite": "1.0.30000846",
+				"electron-to-chromium": "1.3.48"
 			}
 		},
 		"bser": {
@@ -2308,7 +2308,7 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "^0.4.0"
+				"node-int64": "0.4.0"
 			}
 		},
 		"buffer": {
@@ -2317,9 +2317,9 @@
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
+				"base64-js": "1.3.0",
+				"ieee754": "1.1.11",
+				"isarray": "1.0.0"
 			}
 		},
 		"buffer-from": {
@@ -2364,19 +2364,19 @@
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 			"dev": true,
 			"requires": {
-				"bluebird": "^3.5.1",
-				"chownr": "^1.0.1",
-				"glob": "^7.1.2",
-				"graceful-fs": "^4.1.11",
-				"lru-cache": "^4.1.1",
-				"mississippi": "^2.0.0",
-				"mkdirp": "^0.5.1",
-				"move-concurrently": "^1.0.1",
-				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.6.2",
-				"ssri": "^5.2.4",
-				"unique-filename": "^1.1.0",
-				"y18n": "^4.0.0"
+				"bluebird": "3.5.1",
+				"chownr": "1.0.1",
+				"glob": "7.1.2",
+				"graceful-fs": "4.1.11",
+				"lru-cache": "4.1.2",
+				"mississippi": "2.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.2",
+				"ssri": "5.3.0",
+				"unique-filename": "1.1.0",
+				"y18n": "4.0.0"
 			},
 			"dependencies": {
 				"y18n": {
@@ -2393,15 +2393,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
 			}
 		},
 		"cacheable-request": {
@@ -2439,7 +2439,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "0.2.0"
 			},
 			"dependencies": {
 				"callsites": {
@@ -2468,8 +2468,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -2492,7 +2492,7 @@
 			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
 			"dev": true,
 			"requires": {
-				"rsvp": "^3.3.3"
+				"rsvp": "3.6.2"
 			}
 		},
 		"caseless": {
@@ -2508,8 +2508,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "^0.1.3",
-				"lazy-cache": "^1.0.3"
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
 			}
 		},
 		"chalk": {
@@ -2518,9 +2518,9 @@
 			"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.3.0"
 			}
 		},
 		"chardet": {
@@ -2535,12 +2535,12 @@
 			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
 			"dev": true,
 			"requires": {
-				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.0",
-				"entities": "~1.1.1",
-				"htmlparser2": "^3.9.1",
-				"lodash": "^4.15.0",
-				"parse5": "^3.0.1"
+				"css-select": "1.2.0",
+				"dom-serializer": "0.1.0",
+				"entities": "1.1.1",
+				"htmlparser2": "3.9.2",
+				"lodash": "4.17.10",
+				"parse5": "3.0.3"
 			},
 			"dependencies": {
 				"parse5": {
@@ -2549,7 +2549,7 @@
 					"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
 					"dev": true,
 					"requires": {
-						"@types/node": "*"
+						"@types/node": "10.1.4"
 					}
 				}
 			}
@@ -2560,18 +2560,18 @@
 			"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
 			"dev": true,
 			"requires": {
-				"anymatch": "^2.0.0",
-				"async-each": "^1.0.0",
-				"braces": "^2.3.0",
-				"fsevents": "^1.1.2",
-				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"normalize-path": "^2.1.1",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0",
-				"upath": "^1.0.0"
+				"anymatch": "2.0.0",
+				"async-each": "1.0.1",
+				"braces": "2.3.1",
+				"fsevents": "1.2.4",
+				"glob-parent": "3.1.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "4.0.0",
+				"normalize-path": "2.1.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0",
+				"upath": "1.1.0"
 			}
 		},
 		"chownr": {
@@ -2598,8 +2598,8 @@
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"circular-json": {
@@ -2620,10 +2620,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2632,7 +2632,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -2641,7 +2641,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2650,7 +2650,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2661,7 +2661,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2670,7 +2670,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2681,9 +2681,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					}
 				},
 				"kind-of": {
@@ -2700,7 +2700,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-spinners": {
@@ -2733,7 +2733,7 @@
 			"dev": true,
 			"requires": {
 				"slice-ansi": "0.0.4",
-				"string-width": "^1.0.1"
+				"string-width": "1.0.2"
 			},
 			"dependencies": {
 				"string-width": {
@@ -2742,9 +2742,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -2761,9 +2761,9 @@
 			"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
 			"dev": true,
 			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"wrap-ansi": "2.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -2778,7 +2778,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -2801,7 +2801,7 @@
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
 			"dev": true,
 			"requires": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "1.0.0"
 			}
 		},
 		"clone-stats": {
@@ -2816,9 +2816,9 @@
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"process-nextick-args": "^2.0.0",
-				"readable-stream": "^2.3.5"
+				"inherits": "2.0.3",
+				"process-nextick-args": "2.0.0",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"co": {
@@ -2840,7 +2840,7 @@
 			"dev": true,
 			"requires": {
 				"argv": "0.0.2",
-				"request": "^2.81.0",
+				"request": "2.87.0",
 				"urlgrey": "0.4.4"
 			}
 		},
@@ -2850,8 +2850,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color-convert": {
@@ -2860,7 +2860,7 @@
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "^1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
@@ -2881,7 +2881,7 @@
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
@@ -2896,7 +2896,7 @@
 			"integrity": "sha1-+lo/eAEwcBFIZtx7jpzzF6ljX3Q=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.4"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"commondir": {
@@ -2923,7 +2923,7 @@
 			"integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
 			"dev": true,
 			"requires": {
-				"mime-db": ">= 1.33.0 < 2"
+				"mime-db": "1.33.0"
 			}
 		},
 		"compression": {
@@ -2932,13 +2932,13 @@
 			"integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
 			"dev": true,
 			"requires": {
-				"accepts": "~1.3.4",
+				"accepts": "1.3.5",
 				"bytes": "3.0.0",
-				"compressible": "~2.0.13",
+				"compressible": "2.0.13",
 				"debug": "2.6.9",
-				"on-headers": "~1.0.1",
+				"on-headers": "1.0.1",
 				"safe-buffer": "5.1.1",
-				"vary": "~1.1.2"
+				"vary": "1.1.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -2964,9 +2964,9 @@
 			"integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5",
+				"typedarray": "0.0.6"
 			}
 		},
 		"connect-history-api-fallback": {
@@ -2981,7 +2981,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "^0.1.4"
+				"date-now": "0.1.4"
 			}
 		},
 		"constants-browserify": {
@@ -3026,12 +3026,12 @@
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.1.1",
-				"fs-write-stream-atomic": "^1.0.8",
-				"iferr": "^0.1.5",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.4",
-				"run-queue": "^1.0.0"
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
 			}
 		},
 		"copy-descriptor": {
@@ -3058,8 +3058,8 @@
 			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
+				"bn.js": "4.11.8",
+				"elliptic": "6.4.0"
 			}
 		},
 		"create-hash": {
@@ -3068,11 +3068,11 @@
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.3",
+				"md5.js": "1.3.4",
+				"ripemd160": "2.0.2",
+				"sha.js": "2.4.11"
 			}
 		},
 		"create-hmac": {
@@ -3081,12 +3081,12 @@
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"cipher-base": "1.0.4",
+				"create-hash": "1.2.0",
+				"inherits": "2.0.3",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.11"
 			}
 		},
 		"cross-env": {
@@ -3095,8 +3095,8 @@
 			"integrity": "sha512-VWTDq+G4v383SzgRS7jsAVWqEWF0aKZpDz1GVjhONvPRgHB1LnxP2sXUVFKbykHkPSnfRKS8YdiDevWFwZmQ9g==",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.1.0",
-				"is-windows": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"is-windows": "1.0.2"
 			}
 		},
 		"cross-spawn": {
@@ -3105,9 +3105,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"lru-cache": "4.1.2",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
 			}
 		},
 		"crypto-browserify": {
@@ -3116,17 +3116,17 @@
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"dev": true,
 			"requires": {
-				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
-				"create-ecdh": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.0",
-				"diffie-hellman": "^5.0.0",
-				"inherits": "^2.0.1",
-				"pbkdf2": "^3.0.3",
-				"public-encrypt": "^4.0.0",
-				"randombytes": "^2.0.0",
-				"randomfill": "^1.0.3"
+				"browserify-cipher": "1.0.1",
+				"browserify-sign": "4.0.4",
+				"create-ecdh": "4.0.3",
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"diffie-hellman": "5.0.3",
+				"inherits": "2.0.3",
+				"pbkdf2": "3.0.16",
+				"public-encrypt": "4.0.2",
+				"randombytes": "2.0.6",
+				"randomfill": "1.0.4"
 			}
 		},
 		"css-select": {
@@ -3135,10 +3135,10 @@
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"dev": true,
 			"requires": {
-				"boolbase": "~1.0.0",
-				"css-what": "2.1",
+				"boolbase": "1.0.0",
+				"css-what": "2.1.0",
 				"domutils": "1.5.1",
-				"nth-check": "~1.0.1"
+				"nth-check": "1.0.1"
 			}
 		},
 		"css-what": {
@@ -3159,7 +3159,7 @@
 			"integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "0.3.2"
 			}
 		},
 		"currently-unhandled": {
@@ -3168,7 +3168,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "^1.0.1"
+				"array-find-index": "1.0.2"
 			}
 		},
 		"cyclist": {
@@ -3183,7 +3183,7 @@
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"dev": true,
 			"requires": {
-				"es5-ext": "^0.10.9"
+				"es5-ext": "0.10.42"
 			}
 		},
 		"damerau-levenshtein": {
@@ -3204,7 +3204,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"data-urls": {
@@ -3213,9 +3213,9 @@
 			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
 			"dev": true,
 			"requires": {
-				"abab": "^1.0.4",
-				"whatwg-mimetype": "^2.0.0",
-				"whatwg-url": "^6.4.0"
+				"abab": "1.0.4",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1"
 			}
 		},
 		"date-fns": {
@@ -3263,7 +3263,7 @@
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 			"dev": true,
 			"requires": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "1.0.0"
 			}
 		},
 		"deep-equal": {
@@ -3278,7 +3278,7 @@
 			"integrity": "sha1-BvS4nlNxDNbOpKd4HHqVZkLejck=",
 			"dev": true,
 			"requires": {
-				"lodash.isequal": "^3.0"
+				"lodash.isequal": "3.0.4"
 			}
 		},
 		"deep-extend": {
@@ -3299,7 +3299,7 @@
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "^2.0.0"
+				"strip-bom": "2.0.0"
 			}
 		},
 		"define-properties": {
@@ -3308,8 +3308,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "^2.0.5",
-				"object-keys": "^1.0.8"
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
 			}
 		},
 		"define-property": {
@@ -3318,8 +3318,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			}
 		},
 		"del": {
@@ -3328,12 +3328,12 @@
 			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
 			"dev": true,
 			"requires": {
-				"globby": "^6.1.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"p-map": "^1.1.1",
-				"pify": "^3.0.0",
-				"rimraf": "^2.2.8"
+				"globby": "6.1.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"p-map": "1.2.0",
+				"pify": "3.0.0",
+				"rimraf": "2.6.2"
 			},
 			"dependencies": {
 				"globby": {
@@ -3342,11 +3342,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"array-union": "1.0.2",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					},
 					"dependencies": {
 						"pify": {
@@ -3377,8 +3377,8 @@
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"destroy": {
@@ -3399,7 +3399,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"detect-newline": {
@@ -3426,9 +3426,9 @@
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
+				"bn.js": "4.11.8",
+				"miller-rabin": "4.0.1",
+				"randombytes": "2.0.6"
 			}
 		},
 		"dir-glob": {
@@ -3437,8 +3437,8 @@
 			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"path-type": "^3.0.0"
+				"arrify": "1.0.1",
+				"path-type": "3.0.0"
 			},
 			"dependencies": {
 				"path-type": {
@@ -3447,7 +3447,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				}
 			}
@@ -3470,8 +3470,8 @@
 			"integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
 			"dev": true,
 			"requires": {
-				"ip": "^1.1.0",
-				"safe-buffer": "^5.0.1"
+				"ip": "1.1.5",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"dns-txt": {
@@ -3480,7 +3480,7 @@
 			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
 			"dev": true,
 			"requires": {
-				"buffer-indexof": "^1.0.0"
+				"buffer-indexof": "1.1.1"
 			}
 		},
 		"doctrine": {
@@ -3489,7 +3489,7 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2"
+				"esutils": "2.0.2"
 			}
 		},
 		"dom-serializer": {
@@ -3498,8 +3498,8 @@
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "~1.1.1",
-				"entities": "~1.1.1"
+				"domelementtype": "1.1.3",
+				"entities": "1.1.1"
 			},
 			"dependencies": {
 				"domelementtype": {
@@ -3528,7 +3528,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"domhandler": {
@@ -3537,7 +3537,7 @@
 			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "1"
+				"domelementtype": "1.3.0"
 			}
 		},
 		"domutils": {
@@ -3546,8 +3546,8 @@
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
 			"dev": true,
 			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
+				"dom-serializer": "0.1.0",
+				"domelementtype": "1.3.0"
 			}
 		},
 		"duplexer3": {
@@ -3562,10 +3562,10 @@
 			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0",
-				"stream-shift": "^1.0.0"
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5",
+				"stream-shift": "1.0.0"
 			}
 		},
 		"ecc-jsbn": {
@@ -3575,7 +3575,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "~0.1.0"
+				"jsbn": "0.1.1"
 			}
 		},
 		"editions": {
@@ -3614,13 +3614,13 @@
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.3",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"emoji-regex": {
@@ -3646,7 +3646,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "~0.4.13"
+				"iconv-lite": "0.4.19"
 			}
 		},
 		"end-of-stream": {
@@ -3655,7 +3655,7 @@
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"dev": true,
 			"requires": {
-				"once": "^1.4.0"
+				"once": "1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -3664,9 +3664,9 @@
 			"integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
-				"tapable": "^1.0.0"
+				"graceful-fs": "4.1.11",
+				"memory-fs": "0.4.1",
+				"tapable": "1.0.0"
 			}
 		},
 		"entities": {
@@ -3687,22 +3687,22 @@
 			"integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
 			"dev": true,
 			"requires": {
-				"cheerio": "^1.0.0-rc.2",
-				"function.prototype.name": "^1.0.3",
-				"has": "^1.0.1",
-				"is-boolean-object": "^1.0.0",
-				"is-callable": "^1.1.3",
-				"is-number-object": "^1.0.3",
-				"is-string": "^1.0.4",
-				"is-subset": "^0.1.1",
-				"lodash": "^4.17.4",
-				"object-inspect": "^1.5.0",
-				"object-is": "^1.0.1",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.0.4",
-				"object.values": "^1.0.4",
-				"raf": "^3.4.0",
-				"rst-selector-parser": "^2.2.3"
+				"cheerio": "1.0.0-rc.2",
+				"function.prototype.name": "1.1.0",
+				"has": "1.0.1",
+				"is-boolean-object": "1.0.0",
+				"is-callable": "1.1.3",
+				"is-number-object": "1.0.3",
+				"is-string": "1.0.4",
+				"is-subset": "0.1.1",
+				"lodash": "4.17.10",
+				"object-inspect": "1.6.0",
+				"object-is": "1.0.1",
+				"object.assign": "4.1.0",
+				"object.entries": "1.0.4",
+				"object.values": "1.0.4",
+				"raf": "3.4.0",
+				"rst-selector-parser": "2.2.3"
 			}
 		},
 		"enzyme-adapter-react-16": {
@@ -3711,13 +3711,13 @@
 			"integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
 			"dev": true,
 			"requires": {
-				"enzyme-adapter-utils": "^1.3.0",
-				"lodash": "^4.17.4",
-				"object.assign": "^4.0.4",
-				"object.values": "^1.0.4",
-				"prop-types": "^15.6.0",
-				"react-reconciler": "^0.7.0",
-				"react-test-renderer": "^16.0.0-0"
+				"enzyme-adapter-utils": "1.3.0",
+				"lodash": "4.17.10",
+				"object.assign": "4.1.0",
+				"object.values": "1.0.4",
+				"prop-types": "15.6.1",
+				"react-reconciler": "0.7.0",
+				"react-test-renderer": "16.4.0"
 			}
 		},
 		"enzyme-adapter-utils": {
@@ -3726,9 +3726,9 @@
 			"integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.4",
-				"object.assign": "^4.0.4",
-				"prop-types": "^15.6.0"
+				"lodash": "4.17.10",
+				"object.assign": "4.1.0",
+				"prop-types": "15.6.1"
 			}
 		},
 		"enzyme-matchers": {
@@ -3737,8 +3737,8 @@
 			"integrity": "sha1-Hubox/WaRqGrYtlx46/bRbf7PqI=",
 			"dev": true,
 			"requires": {
-				"circular-json-es6": "^2.0.1",
-				"deep-equal-ident": "^1.1.1"
+				"circular-json-es6": "2.0.2",
+				"deep-equal-ident": "1.1.1"
 			}
 		},
 		"enzyme-to-json": {
@@ -3747,7 +3747,7 @@
 			"integrity": "sha1-Z8YEDpMRgvGDQYry659DIyWKp38=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.4"
+				"lodash": "4.17.10"
 			}
 		},
 		"errno": {
@@ -3756,7 +3756,7 @@
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"dev": true,
 			"requires": {
-				"prr": "~1.0.1"
+				"prr": "1.0.1"
 			}
 		},
 		"error": {
@@ -3765,8 +3765,8 @@
 			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
 			"dev": true,
 			"requires": {
-				"string-template": "~0.2.1",
-				"xtend": "~4.0.0"
+				"string-template": "0.2.1",
+				"xtend": "4.0.1"
 			}
 		},
 		"error-ex": {
@@ -3775,7 +3775,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -3784,11 +3784,11 @@
 			"integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -3797,9 +3797,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.1",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
 			}
 		},
 		"es5-ext": {
@@ -3808,9 +3808,9 @@
 			"integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
 			"dev": true,
 			"requires": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "1"
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1",
+				"next-tick": "1.0.0"
 			}
 		},
 		"es6-iterator": {
@@ -3819,9 +3819,9 @@
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
 			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
+				"d": "1.0.0",
+				"es5-ext": "0.10.42",
+				"es6-symbol": "3.1.1"
 			}
 		},
 		"es6-symbol": {
@@ -3830,8 +3830,8 @@
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 			"dev": true,
 			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
+				"d": "1.0.0",
+				"es5-ext": "0.10.42"
 			}
 		},
 		"escape-html": {
@@ -3852,11 +3852,11 @@
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
 			"dev": true,
 			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -3880,44 +3880,44 @@
 			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"babel-code-frame": "^6.22.0",
-				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
-				"debug": "^3.1.0",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^3.7.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.4",
-				"esquery": "^1.0.0",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
-				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
-				"globals": "^11.0.1",
-				"ignore": "^3.3.3",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
-				"progress": "^2.0.0",
-				"regexpp": "^1.0.1",
-				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.3.2",
+				"concat-stream": "1.6.1",
+				"cross-spawn": "5.1.0",
+				"debug": "3.1.0",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "3.5.4",
+				"esquery": "1.0.0",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.2",
+				"globals": "11.4.0",
+				"ignore": "3.3.7",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.11.0",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.10",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.0",
+				"regexpp": "1.0.1",
+				"require-uncached": "1.0.3",
+				"semver": "5.5.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
 				"table": "4.0.2",
-				"text-table": "~0.2.0"
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -3926,10 +3926,10 @@
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"co": "4.6.0",
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
 					}
 				},
 				"ansi-regex": {
@@ -3950,20 +3950,20 @@
 					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.4",
-						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
+						"ansi-escapes": "3.0.0",
+						"chalk": "2.3.2",
+						"cli-cursor": "2.1.0",
+						"cli-width": "2.2.0",
+						"external-editor": "2.1.0",
+						"figures": "2.0.0",
+						"lodash": "4.17.10",
 						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rx-lite": "^4.0.8",
-						"rx-lite-aggregates": "^4.0.8",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
-						"through": "^2.3.6"
+						"run-async": "2.3.0",
+						"rx-lite": "4.0.8",
+						"rx-lite-aggregates": "4.0.8",
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"through": "2.3.8"
 					}
 				},
 				"strip-ansi": {
@@ -3972,7 +3972,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -4001,8 +4001,8 @@
 			"integrity": "sha512-qoNpVicVWGjGBXAJsqRoqVuAnajgX7PWtSa2Men36XKRiXe3RS/QmRv215PXZwo4OHskYOsUoJUeiPiWtS9ULA==",
 			"dev": true,
 			"requires": {
-				"comment-parser": "^0.4.2",
-				"lodash": "^4.17.4"
+				"comment-parser": "0.4.2",
+				"lodash": "4.17.10"
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
@@ -4011,13 +4011,13 @@
 			"integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
 			"dev": true,
 			"requires": {
-				"aria-query": "^0.7.0",
-				"array-includes": "^3.0.3",
+				"aria-query": "0.7.1",
+				"array-includes": "3.0.3",
 				"ast-types-flow": "0.0.7",
-				"axobject-query": "^0.1.0",
-				"damerau-levenshtein": "^1.0.0",
-				"emoji-regex": "^6.1.0",
-				"jsx-ast-utils": "^2.0.0"
+				"axobject-query": "0.1.0",
+				"damerau-levenshtein": "1.0.4",
+				"emoji-regex": "6.5.1",
+				"jsx-ast-utils": "2.0.1"
 			}
 		},
 		"eslint-plugin-node": {
@@ -4026,10 +4026,10 @@
 			"integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
 			"dev": true,
 			"requires": {
-				"ignore": "^3.3.6",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.3.3",
-				"semver": "^5.4.1"
+				"ignore": "3.3.7",
+				"minimatch": "3.0.4",
+				"resolve": "1.7.1",
+				"semver": "5.5.0"
 			}
 		},
 		"eslint-plugin-react": {
@@ -4038,22 +4038,21 @@
 			"integrity": "sha512-H3ne8ob4Bn6NXSN9N9twsn7t8dyHT5bF/ibQepxIHi6JiPIdC2gXlfYvZYucbdrWio4FxBq7Z4mSauQP+qmMkQ==",
 			"dev": true,
 			"requires": {
-				"doctrine": "^2.0.2",
-				"has": "^1.0.1",
-				"jsx-ast-utils": "^2.0.1",
-				"prop-types": "^15.6.0"
+				"doctrine": "2.1.0",
+				"has": "1.0.1",
+				"jsx-ast-utils": "2.0.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"eslint-plugin-wordpress": {
 			"version": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git#a517eed42208c4dc6d66a0d9e8a35acd3573a182",
-			"from": "git://github.com/WordPress-Coding-Standards/eslint-plugin-wordpress.git",
 			"dev": true,
 			"requires": {
-				"eslint-plugin-i18n": "~1.2.0",
-				"eslint-plugin-jsdoc": "~3.5.0",
-				"eslint-plugin-node": "~6.0.1",
-				"eslint-plugin-wpcalypso": "~4.0.1",
-				"merge": "~1.2.0"
+				"eslint-plugin-i18n": "1.2.0",
+				"eslint-plugin-jsdoc": "3.5.0",
+				"eslint-plugin-node": "6.0.1",
+				"eslint-plugin-wpcalypso": "4.0.1",
+				"merge": "1.2.0"
 			}
 		},
 		"eslint-plugin-wpcalypso": {
@@ -4062,7 +4061,7 @@
 			"integrity": "sha512-fU5NSc0XGdel/tlEIUoESOdqphBWQN2FfSgXXNHpXKX7ftTcqXacqgzXU8OVziyhXz6s2RUzK0+JSJaNxhZ+Mw==",
 			"dev": true,
 			"requires": {
-				"requireindex": "^1.1.0"
+				"requireindex": "1.2.0"
 			}
 		},
 		"eslint-scope": {
@@ -4071,8 +4070,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -4087,8 +4086,8 @@
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"dev": true,
 			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "5.5.3",
+				"acorn-jsx": "3.0.1"
 			}
 		},
 		"esprima": {
@@ -4103,7 +4102,7 @@
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"esrecurse": {
@@ -4112,7 +4111,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"estraverse": {
@@ -4157,7 +4156,7 @@
 			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
 			"dev": true,
 			"requires": {
-				"original": ">=0.0.5"
+				"original": "1.0.1"
 			}
 		},
 		"evp_bytestokey": {
@@ -4166,8 +4165,8 @@
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"dev": true,
 			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
+				"md5.js": "1.3.4",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"exec-sh": {
@@ -4176,7 +4175,7 @@
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"dev": true,
 			"requires": {
-				"merge": "^1.1.3"
+				"merge": "1.2.0"
 			}
 		},
 		"execa": {
@@ -4185,13 +4184,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"exit": {
@@ -4212,13 +4211,13 @@
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.3.3",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"posix-character-classes": "^0.1.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"posix-character-classes": "0.1.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -4236,7 +4235,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -4245,7 +4244,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -4254,7 +4253,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4263,7 +4262,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4274,7 +4273,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4283,7 +4282,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4294,9 +4293,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					}
 				},
 				"kind-of": {
@@ -4313,7 +4312,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.3"
 			},
 			"dependencies": {
 				"fill-range": {
@@ -4322,11 +4321,11 @@
 					"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 					"dev": true,
 					"requires": {
-						"is-number": "^2.1.0",
-						"isobject": "^2.0.0",
-						"randomatic": "^1.1.3",
-						"repeat-element": "^1.1.2",
-						"repeat-string": "^1.5.2"
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "1.1.7",
+						"repeat-element": "1.1.2",
+						"repeat-string": "1.6.1"
 					}
 				},
 				"is-number": {
@@ -4335,7 +4334,7 @@
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"isobject": {
@@ -4353,7 +4352,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -4364,7 +4363,7 @@
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"dev": true,
 			"requires": {
-				"homedir-polyfill": "^1.0.1"
+				"homedir-polyfill": "1.0.1"
 			}
 		},
 		"expect": {
@@ -4373,12 +4372,12 @@
 			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"jest-diff": "^22.4.3",
-				"jest-get-type": "^22.4.3",
-				"jest-matcher-utils": "^22.4.3",
-				"jest-message-util": "^22.4.3",
-				"jest-regex-util": "^22.4.3"
+				"ansi-styles": "3.2.1",
+				"jest-diff": "22.4.3",
+				"jest-get-type": "22.4.3",
+				"jest-matcher-utils": "22.4.3",
+				"jest-message-util": "22.4.3",
+				"jest-regex-util": "22.4.3"
 			}
 		},
 		"express": {
@@ -4387,36 +4386,36 @@
 			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
 			"dev": true,
 			"requires": {
-				"accepts": "~1.3.5",
+				"accepts": "1.3.5",
 				"array-flatten": "1.1.1",
 				"body-parser": "1.18.2",
 				"content-disposition": "0.5.2",
-				"content-type": "~1.0.4",
+				"content-type": "1.0.4",
 				"cookie": "0.3.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
+				"depd": "1.1.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
 				"finalhandler": "1.1.1",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.3",
+				"proxy-addr": "2.0.3",
 				"qs": "6.5.1",
-				"range-parser": "~1.2.0",
+				"range-parser": "1.2.0",
 				"safe-buffer": "5.1.1",
 				"send": "0.16.2",
 				"serve-static": "1.13.2",
 				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
+				"statuses": "1.4.0",
+				"type-is": "1.6.16",
 				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
+				"vary": "1.1.2"
 			},
 			"dependencies": {
 				"array-flatten": {
@@ -4448,8 +4447,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -4458,7 +4457,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -4469,9 +4468,9 @@
 			"integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.19",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -4480,14 +4479,14 @@
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"dev": true,
 			"requires": {
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"expand-brackets": "^2.1.4",
-				"extend-shallow": "^2.0.1",
-				"fragment-cache": "^0.2.1",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"array-unique": "0.3.2",
+				"define-property": "1.0.0",
+				"expand-brackets": "2.1.4",
+				"extend-shallow": "2.0.1",
+				"fragment-cache": "0.2.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -4496,7 +4495,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"extend-shallow": {
@@ -4505,7 +4504,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -4528,12 +4527,12 @@
 			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
 			"dev": true,
 			"requires": {
-				"@mrmlnc/readdir-enhanced": "^2.2.1",
-				"@nodelib/fs.stat": "^1.0.1",
-				"glob-parent": "^3.1.0",
-				"is-glob": "^4.0.0",
-				"merge2": "^1.2.1",
-				"micromatch": "^3.1.10"
+				"@mrmlnc/readdir-enhanced": "2.2.1",
+				"@nodelib/fs.stat": "1.1.0",
+				"glob-parent": "3.1.0",
+				"is-glob": "4.0.0",
+				"merge2": "1.2.2",
+				"micromatch": "3.1.10"
 			},
 			"dependencies": {
 				"micromatch": {
@@ -4542,19 +4541,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.1",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				}
 			}
@@ -4577,7 +4576,7 @@
 			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
 			"dev": true,
 			"requires": {
-				"websocket-driver": ">=0.5.1"
+				"websocket-driver": "0.7.0"
 			}
 		},
 		"fb-watchman": {
@@ -4586,7 +4585,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.0.0"
 			}
 		},
 		"fbjs": {
@@ -4594,13 +4593,13 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.9"
+				"core-js": "1.2.7",
+				"isomorphic-fetch": "2.2.1",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"promise": "7.3.1",
+				"setimmediate": "1.0.5",
+				"ua-parser-js": "0.7.17"
 			},
 			"dependencies": {
 				"core-js": {
@@ -4616,7 +4615,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -4625,8 +4624,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
 			}
 		},
 		"filename-regex": {
@@ -4641,8 +4640,8 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
 			}
 		},
 		"fill-range": {
@@ -4651,10 +4650,10 @@
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
+				"extend-shallow": "2.0.1",
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1",
+				"to-regex-range": "2.1.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -4663,7 +4662,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -4675,12 +4674,12 @@
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
-				"unpipe": "~1.0.0"
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.4.0",
+				"unpipe": "1.0.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -4700,9 +4699,9 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
-				"pkg-dir": "^2.0.0"
+				"commondir": "1.0.1",
+				"make-dir": "1.2.0",
+				"pkg-dir": "2.0.0"
 			}
 		},
 		"find-up": {
@@ -4711,7 +4710,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"first-chunk-stream": {
@@ -4720,7 +4719,7 @@
 			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.2"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"flat-cache": {
@@ -4729,10 +4728,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"write": "^0.2.1"
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
 			},
 			"dependencies": {
 				"del": {
@@ -4741,13 +4740,13 @@
 					"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 					"dev": true,
 					"requires": {
-						"globby": "^5.0.0",
-						"is-path-cwd": "^1.0.0",
-						"is-path-in-cwd": "^1.0.0",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"rimraf": "^2.2.8"
+						"globby": "5.0.0",
+						"is-path-cwd": "1.0.0",
+						"is-path-in-cwd": "1.0.0",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"rimraf": "2.6.2"
 					}
 				},
 				"globby": {
@@ -4756,12 +4755,12 @@
 					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"arrify": "^1.0.0",
-						"glob": "^7.0.3",
-						"object-assign": "^4.0.1",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"array-union": "1.0.2",
+						"arrify": "1.0.1",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pify": {
@@ -4784,8 +4783,8 @@
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.4"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"follow-redirects": {
@@ -4794,7 +4793,7 @@
 			"integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0"
+				"debug": "3.1.0"
 			}
 		},
 		"for-in": {
@@ -4809,7 +4808,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"foreach": {
@@ -4830,9 +4829,9 @@
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
+				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "^2.1.12"
+				"mime-types": "2.1.18"
 			}
 		},
 		"forwarded": {
@@ -4847,7 +4846,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"fresh": {
@@ -4862,8 +4861,8 @@
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"fs-readdir-recursive": {
@@ -4878,10 +4877,10 @@
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"iferr": "^0.1.5",
-				"imurmurhash": "^0.1.4",
-				"readable-stream": "1 || 2"
+				"graceful-fs": "4.1.11",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"fs.realpath": {
@@ -4897,8 +4896,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "2.10.0",
+				"node-pre-gyp": "0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -4924,8 +4923,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"balanced-match": {
@@ -4938,7 +4937,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -5002,7 +5001,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"fs.realpath": {
@@ -5017,14 +5016,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"glob": {
@@ -5033,12 +5032,12 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-unicode": {
@@ -5053,7 +5052,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"ignore-walk": {
@@ -5062,7 +5061,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"inflight": {
@@ -5071,8 +5070,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -5091,7 +5090,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -5105,7 +5104,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -5118,8 +5117,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"minizlib": {
@@ -5128,7 +5127,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"mkdirp": {
@@ -5151,9 +5150,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
+						"debug": "2.6.9",
+						"iconv-lite": "0.4.21",
+						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -5162,16 +5161,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.2.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.1.10",
+						"npmlog": "4.1.2",
+						"rc": "1.2.7",
+						"rimraf": "2.6.2",
+						"semver": "5.5.0",
+						"tar": "4.4.1"
 					}
 				},
 				"nopt": {
@@ -5180,8 +5179,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"npm-bundled": {
@@ -5196,8 +5195,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
 					}
 				},
 				"npmlog": {
@@ -5206,10 +5205,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -5228,7 +5227,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -5249,8 +5248,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -5271,10 +5270,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.5.1",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -5291,13 +5290,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
@@ -5306,7 +5305,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -5349,9 +5348,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -5360,7 +5359,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.1"
 					}
 				},
 				"strip-ansi": {
@@ -5368,7 +5367,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -5383,13 +5382,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -5404,7 +5403,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
@@ -5431,9 +5430,9 @@
 			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"is-callable": "^1.1.3"
+				"define-properties": "1.1.2",
+				"function-bind": "1.1.1",
+				"is-callable": "1.1.3"
 			}
 		},
 		"functional-red-black-tree": {
@@ -5472,7 +5471,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"gh-got": {
@@ -5481,8 +5480,8 @@
 			"integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
 			"dev": true,
 			"requires": {
-				"got": "^7.0.0",
-				"is-plain-obj": "^1.1.0"
+				"got": "7.1.0",
+				"is-plain-obj": "1.1.0"
 			},
 			"dependencies": {
 				"got": {
@@ -5491,20 +5490,20 @@
 					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
 					"dev": true,
 					"requires": {
-						"decompress-response": "^3.2.0",
-						"duplexer3": "^0.1.4",
-						"get-stream": "^3.0.0",
-						"is-plain-obj": "^1.1.0",
-						"is-retry-allowed": "^1.0.0",
-						"is-stream": "^1.0.0",
-						"isurl": "^1.0.0-alpha5",
-						"lowercase-keys": "^1.0.0",
-						"p-cancelable": "^0.3.0",
-						"p-timeout": "^1.1.1",
-						"safe-buffer": "^5.0.1",
-						"timed-out": "^4.0.0",
-						"url-parse-lax": "^1.0.0",
-						"url-to-options": "^1.0.1"
+						"decompress-response": "3.3.0",
+						"duplexer3": "0.1.4",
+						"get-stream": "3.0.0",
+						"is-plain-obj": "1.1.0",
+						"is-retry-allowed": "1.1.0",
+						"is-stream": "1.1.0",
+						"isurl": "1.0.0",
+						"lowercase-keys": "1.0.1",
+						"p-cancelable": "0.3.0",
+						"p-timeout": "1.2.1",
+						"safe-buffer": "5.1.1",
+						"timed-out": "4.0.1",
+						"url-parse-lax": "1.0.0",
+						"url-to-options": "1.0.1"
 					}
 				},
 				"p-cancelable": {
@@ -5519,7 +5518,7 @@
 					"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
 					"dev": true,
 					"requires": {
-						"p-finally": "^1.0.0"
+						"p-finally": "1.0.0"
 					}
 				},
 				"prepend-http": {
@@ -5534,7 +5533,7 @@
 					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"dev": true,
 					"requires": {
-						"prepend-http": "^1.0.1"
+						"prepend-http": "1.0.4"
 					}
 				}
 			}
@@ -5545,7 +5544,7 @@
 			"integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
 			"dev": true,
 			"requires": {
-				"gh-got": "^6.0.0"
+				"gh-got": "6.0.0"
 			}
 		},
 		"glob": {
@@ -5554,12 +5553,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-all": {
@@ -5568,8 +5567,8 @@
 			"integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5",
-				"yargs": "~1.2.6"
+				"glob": "7.1.2",
+				"yargs": "1.2.6"
 			},
 			"dependencies": {
 				"minimist": {
@@ -5584,7 +5583,7 @@
 					"integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
 					"dev": true,
 					"requires": {
-						"minimist": "^0.1.0"
+						"minimist": "0.1.0"
 					}
 				}
 			}
@@ -5595,8 +5594,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			},
 			"dependencies": {
 				"glob-parent": {
@@ -5605,7 +5604,7 @@
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 					"dev": true,
 					"requires": {
-						"is-glob": "^2.0.0"
+						"is-glob": "2.0.1"
 					}
 				},
 				"is-extglob": {
@@ -5620,7 +5619,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				}
 			}
@@ -5631,8 +5630,8 @@
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"dev": true,
 			"requires": {
-				"is-glob": "^3.1.0",
-				"path-dirname": "^1.0.0"
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
 			},
 			"dependencies": {
 				"is-glob": {
@@ -5641,7 +5640,7 @@
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.0"
+						"is-extglob": "2.1.1"
 					}
 				}
 			}
@@ -5658,9 +5657,9 @@
 			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
 			"dev": true,
 			"requires": {
-				"global-prefix": "^1.0.1",
-				"is-windows": "^1.0.1",
-				"resolve-dir": "^1.0.0"
+				"global-prefix": "1.0.2",
+				"is-windows": "1.0.2",
+				"resolve-dir": "1.0.1"
 			}
 		},
 		"global-prefix": {
@@ -5669,11 +5668,11 @@
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.2",
-				"homedir-polyfill": "^1.0.1",
-				"ini": "^1.3.4",
-				"is-windows": "^1.0.1",
-				"which": "^1.2.14"
+				"expand-tilde": "2.0.2",
+				"homedir-polyfill": "1.0.1",
+				"ini": "1.3.5",
+				"is-windows": "1.0.2",
+				"which": "1.3.0"
 			}
 		},
 		"globals": {
@@ -5688,13 +5687,13 @@
 			"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 			"dev": true,
 			"requires": {
-				"array-union": "^1.0.1",
-				"dir-glob": "^2.0.0",
-				"fast-glob": "^2.0.2",
-				"glob": "^7.1.2",
-				"ignore": "^3.3.5",
-				"pify": "^3.0.0",
-				"slash": "^1.0.0"
+				"array-union": "1.0.2",
+				"dir-glob": "2.0.0",
+				"fast-glob": "2.2.2",
+				"glob": "7.1.2",
+				"ignore": "3.3.7",
+				"pify": "3.0.0",
+				"slash": "1.0.0"
 			}
 		},
 		"got": {
@@ -5703,23 +5702,23 @@
 			"integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
 			"dev": true,
 			"requires": {
-				"@sindresorhus/is": "^0.7.0",
-				"cacheable-request": "^2.1.1",
-				"decompress-response": "^3.3.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^3.0.0",
-				"into-stream": "^3.1.0",
-				"is-retry-allowed": "^1.1.0",
-				"isurl": "^1.0.0-alpha5",
-				"lowercase-keys": "^1.0.0",
-				"mimic-response": "^1.0.0",
-				"p-cancelable": "^0.4.0",
-				"p-timeout": "^2.0.1",
-				"pify": "^3.0.0",
-				"safe-buffer": "^5.1.1",
-				"timed-out": "^4.0.1",
-				"url-parse-lax": "^3.0.0",
-				"url-to-options": "^1.0.1"
+				"@sindresorhus/is": "0.7.0",
+				"cacheable-request": "2.1.4",
+				"decompress-response": "3.3.0",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"into-stream": "3.1.0",
+				"is-retry-allowed": "1.1.0",
+				"isurl": "1.0.0",
+				"lowercase-keys": "1.0.1",
+				"mimic-response": "1.0.0",
+				"p-cancelable": "0.4.1",
+				"p-timeout": "2.0.1",
+				"pify": "3.0.0",
+				"safe-buffer": "5.1.1",
+				"timed-out": "4.0.1",
+				"url-parse-lax": "3.0.0",
+				"url-to-options": "1.0.1"
 			}
 		},
 		"graceful-fs": {
@@ -5734,7 +5733,7 @@
 			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.2"
+				"lodash": "4.17.10"
 			}
 		},
 		"growly": {
@@ -5755,10 +5754,10 @@
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"dev": true,
 			"requires": {
-				"async": "^1.4.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.4.4",
-				"uglify-js": "^2.6"
+				"async": "1.5.2",
+				"optimist": "0.6.1",
+				"source-map": "0.4.4",
+				"uglify-js": "2.8.29"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -5775,8 +5774,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"center-align": "^0.1.1",
-						"right-align": "^0.1.1",
+						"center-align": "0.1.3",
+						"right-align": "0.1.3",
 						"wordwrap": "0.0.2"
 					}
 				},
@@ -5786,7 +5785,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				},
 				"uglify-js": {
@@ -5796,9 +5795,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"source-map": "~0.5.1",
-						"uglify-to-browserify": "~1.0.0",
-						"yargs": "~3.10.0"
+						"source-map": "0.5.7",
+						"uglify-to-browserify": "1.0.2",
+						"yargs": "3.10.0"
 					},
 					"dependencies": {
 						"source-map": {
@@ -5824,9 +5823,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"camelcase": "^1.0.2",
-						"cliui": "^2.1.0",
-						"decamelize": "^1.0.0",
+						"camelcase": "1.2.1",
+						"cliui": "2.1.0",
+						"decamelize": "1.2.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -5844,8 +5843,8 @@
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.1.0",
-				"har-schema": "^2.0.0"
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -5854,10 +5853,10 @@
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"co": "4.6.0",
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
 					}
 				}
 			}
@@ -5874,7 +5873,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.0.2"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -5883,7 +5882,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-color": {
@@ -5916,7 +5915,7 @@
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
 			"dev": true,
 			"requires": {
-				"has-symbol-support-x": "^1.4.1"
+				"has-symbol-support-x": "1.4.2"
 			}
 		},
 		"has-value": {
@@ -5925,9 +5924,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			}
 		},
 		"has-values": {
@@ -5936,8 +5935,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5946,7 +5945,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5957,8 +5956,8 @@
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"hash.js": {
@@ -5967,8 +5966,8 @@
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.0"
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"hmac-drbg": {
@@ -5977,9 +5976,9 @@
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"dev": true,
 			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
+				"hash.js": "1.1.3",
+				"minimalistic-assert": "1.0.1",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"hoist-non-react-statics": {
@@ -5994,8 +5993,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"homedir-polyfill": {
@@ -6004,7 +6003,7 @@
 			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
 			"dev": true,
 			"requires": {
-				"parse-passwd": "^1.0.0"
+				"parse-passwd": "1.0.0"
 			}
 		},
 		"hosted-git-info": {
@@ -6019,10 +6018,10 @@
 			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"obuf": "^1.0.0",
-				"readable-stream": "^2.0.1",
-				"wbuf": "^1.1.0"
+				"inherits": "2.0.3",
+				"obuf": "1.1.2",
+				"readable-stream": "2.3.5",
+				"wbuf": "1.7.3"
 			}
 		},
 		"html-encoding-sniffer": {
@@ -6031,7 +6030,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "1.0.3"
 			}
 		},
 		"html-entities": {
@@ -6046,12 +6045,12 @@
 			"integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
 			"dev": true,
 			"requires": {
-				"domelementtype": "^1.3.0",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.2"
+				"domelementtype": "1.3.0",
+				"domhandler": "2.4.2",
+				"domutils": "1.5.1",
+				"entities": "1.1.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"http-cache-semantics": {
@@ -6072,10 +6071,10 @@
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"dev": true,
 			"requires": {
-				"depd": "~1.1.2",
+				"depd": "1.1.2",
 				"inherits": "2.0.3",
 				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"statuses": "1.4.0"
 			}
 		},
 		"http-parser-js": {
@@ -6090,9 +6089,9 @@
 			"integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
 			"dev": true,
 			"requires": {
-				"eventemitter3": "^3.0.0",
-				"follow-redirects": "^1.0.0",
-				"requires-port": "^1.0.0"
+				"eventemitter3": "3.1.0",
+				"follow-redirects": "1.5.0",
+				"requires-port": "1.0.0"
 			}
 		},
 		"http-proxy-middleware": {
@@ -6101,10 +6100,10 @@
 			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
 			"dev": true,
 			"requires": {
-				"http-proxy": "^1.16.2",
-				"is-glob": "^4.0.0",
-				"lodash": "^4.17.5",
-				"micromatch": "^3.1.9"
+				"http-proxy": "1.17.0",
+				"is-glob": "4.0.0",
+				"lodash": "4.17.10",
+				"micromatch": "3.1.9"
 			}
 		},
 		"http-signature": {
@@ -6113,9 +6112,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.14.1"
 			}
 		},
 		"https-browserify": {
@@ -6135,7 +6134,7 @@
 			"integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
 			"dev": true,
 			"requires": {
-				"harmony-reflect": "^1.4.6"
+				"harmony-reflect": "1.6.0"
 			}
 		},
 		"ieee754": {
@@ -6162,8 +6161,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
-				"resolve-cwd": "^2.0.0"
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -6178,7 +6177,7 @@
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"indexof": {
@@ -6193,8 +6192,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -6215,19 +6214,19 @@
 			"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.1.0",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"ansi-escapes": "3.0.0",
+				"chalk": "2.3.2",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.10",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rxjs": "^5.5.2",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rxjs": "5.5.11",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6242,7 +6241,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -6253,7 +6252,7 @@
 			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
 			"dev": true,
 			"requires": {
-				"meow": "^3.3.0"
+				"meow": "3.7.0"
 			}
 		},
 		"interpret": {
@@ -6268,8 +6267,8 @@
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
 			"dev": true,
 			"requires": {
-				"from2": "^2.1.1",
-				"p-is-promise": "^1.1.0"
+				"from2": "2.3.0",
+				"p-is-promise": "1.1.0"
 			}
 		},
 		"invariant": {
@@ -6278,7 +6277,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.3.1"
 			}
 		},
 		"invert-kv": {
@@ -6305,7 +6304,7 @@
 			"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.0"
+				"kind-of": "6.0.2"
 			}
 		},
 		"is-arrayish": {
@@ -6320,7 +6319,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "^1.0.0"
+				"binary-extensions": "1.11.0"
 			}
 		},
 		"is-boolean-object": {
@@ -6341,7 +6340,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-callable": {
@@ -6356,7 +6355,7 @@
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.0.0"
+				"ci-info": "1.1.3"
 			}
 		},
 		"is-data-descriptor": {
@@ -6365,7 +6364,7 @@
 			"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.0"
+				"kind-of": "6.0.2"
 			}
 		},
 		"is-date-object": {
@@ -6380,9 +6379,9 @@
 			"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "^1.0.0",
-				"is-data-descriptor": "^1.0.0",
-				"kind-of": "^6.0.2"
+				"is-accessor-descriptor": "1.0.0",
+				"is-data-descriptor": "1.0.0",
+				"kind-of": "6.0.2"
 			}
 		},
 		"is-dotfile": {
@@ -6397,7 +6396,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -6418,7 +6417,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -6427,7 +6426,7 @@
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-generator-fn": {
@@ -6442,7 +6441,7 @@
 			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^2.1.1"
+				"is-extglob": "2.1.1"
 			}
 		},
 		"is-module": {
@@ -6457,7 +6456,7 @@
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -6466,7 +6465,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -6489,7 +6488,7 @@
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
 			"dev": true,
 			"requires": {
-				"symbol-observable": "^1.1.0"
+				"symbol-observable": "1.2.0"
 			},
 			"dependencies": {
 				"symbol-observable": {
@@ -6506,7 +6505,7 @@
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0"
+				"is-number": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6529,7 +6528,7 @@
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "1.0.1"
 			}
 		},
 		"is-path-inside": {
@@ -6538,7 +6537,7 @@
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -6553,7 +6552,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"is-posix-bracket": {
@@ -6580,7 +6579,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.1"
 			}
 		},
 		"is-resolvable": {
@@ -6601,7 +6600,7 @@
 			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
 			"dev": true,
 			"requires": {
-				"scoped-regex": "^1.0.0"
+				"scoped-regex": "1.0.0"
 			}
 		},
 		"is-stream": {
@@ -6680,8 +6679,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
+				"node-fetch": "1.7.3",
+				"whatwg-fetch": "2.0.3"
 			}
 		},
 		"isstream": {
@@ -6696,18 +6695,18 @@
 			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.4",
-				"compare-versions": "^3.1.0",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.0",
-				"istanbul-lib-hook": "^1.2.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"istanbul-lib-report": "^1.1.4",
-				"istanbul-lib-source-maps": "^1.2.4",
-				"istanbul-reports": "^1.3.0",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"once": "^1.4.0"
+				"async": "2.6.1",
+				"compare-versions": "3.2.1",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.2.0",
+				"istanbul-lib-hook": "1.2.0",
+				"istanbul-lib-instrument": "1.10.1",
+				"istanbul-lib-report": "1.1.4",
+				"istanbul-lib-source-maps": "1.2.4",
+				"istanbul-reports": "1.3.0",
+				"js-yaml": "3.11.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
 			},
 			"dependencies": {
 				"async": {
@@ -6716,7 +6715,7 @@
 					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.17.10"
+						"lodash": "4.17.10"
 					}
 				},
 				"istanbul-lib-source-maps": {
@@ -6725,11 +6724,11 @@
 					"integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
 					"dev": true,
 					"requires": {
-						"debug": "^3.1.0",
-						"istanbul-lib-coverage": "^1.2.0",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.6.1",
-						"source-map": "^0.5.3"
+						"debug": "3.1.0",
+						"istanbul-lib-coverage": "1.2.0",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.2",
+						"source-map": "0.5.7"
 					}
 				},
 				"lodash": {
@@ -6752,7 +6751,7 @@
 			"integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
 			"dev": true,
 			"requires": {
-				"append-transform": "^0.4.0"
+				"append-transform": "0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -6761,13 +6760,13 @@
 			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.0",
-				"semver": "^5.3.0"
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.2.0",
+				"semver": "5.5.0"
 			},
 			"dependencies": {
 				"babylon": {
@@ -6784,10 +6783,10 @@
 			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.0",
-				"mkdirp": "^0.5.1",
-				"path-parse": "^1.0.5",
-				"supports-color": "^3.1.2"
+				"istanbul-lib-coverage": "1.2.0",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.5",
+				"supports-color": "3.2.3"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -6802,7 +6801,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "1.0.0"
 					}
 				}
 			}
@@ -6813,11 +6812,11 @@
 			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.1.2",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.1",
-				"source-map": "^0.5.3"
+				"debug": "3.1.0",
+				"istanbul-lib-coverage": "1.2.0",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
 			}
 		},
 		"istanbul-reports": {
@@ -6826,7 +6825,7 @@
 			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.0.3"
+				"handlebars": "4.0.11"
 			}
 		},
 		"istextorbinary": {
@@ -6835,9 +6834,9 @@
 			"integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
 			"dev": true,
 			"requires": {
-				"binaryextensions": "2",
-				"editions": "^1.3.3",
-				"textextensions": "2"
+				"binaryextensions": "2.1.1",
+				"editions": "1.3.4",
+				"textextensions": "2.2.0"
 			}
 		},
 		"isurl": {
@@ -6846,8 +6845,8 @@
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
 			"dev": true,
 			"requires": {
-				"has-to-string-tag-x": "^1.2.0",
-				"is-object": "^1.0.1"
+				"has-to-string-tag-x": "1.4.1",
+				"is-object": "1.0.1"
 			}
 		},
 		"jest": {
@@ -6856,8 +6855,8 @@
 			"integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
 			"dev": true,
 			"requires": {
-				"import-local": "^1.0.0",
-				"jest-cli": "^22.4.4"
+				"import-local": "1.0.0",
+				"jest-cli": "22.4.4"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6872,7 +6871,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -6887,9 +6886,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"expand-brackets": {
@@ -6898,7 +6897,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -6907,7 +6906,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"is-extglob": {
@@ -6922,7 +6921,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"jest-cli": {
@@ -6931,40 +6930,40 @@
 					"integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"import-local": "^1.0.0",
-						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.1.14",
-						"istanbul-lib-coverage": "^1.1.1",
-						"istanbul-lib-instrument": "^1.8.0",
-						"istanbul-lib-source-maps": "^1.2.1",
-						"jest-changed-files": "^22.2.0",
-						"jest-config": "^22.4.4",
-						"jest-environment-jsdom": "^22.4.1",
-						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^22.4.2",
-						"jest-message-util": "^22.4.0",
-						"jest-regex-util": "^22.1.0",
-						"jest-resolve-dependencies": "^22.1.0",
-						"jest-runner": "^22.4.4",
-						"jest-runtime": "^22.4.4",
-						"jest-snapshot": "^22.4.0",
-						"jest-util": "^22.4.1",
-						"jest-validate": "^22.4.4",
-						"jest-worker": "^22.2.2",
-						"micromatch": "^2.3.11",
-						"node-notifier": "^5.2.1",
-						"realpath-native": "^1.0.0",
-						"rimraf": "^2.5.4",
-						"slash": "^1.0.0",
-						"string-length": "^2.0.0",
-						"strip-ansi": "^4.0.0",
-						"which": "^1.2.12",
-						"yargs": "^10.0.3"
+						"ansi-escapes": "3.0.0",
+						"chalk": "2.3.2",
+						"exit": "0.1.2",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.1.0",
+						"istanbul-api": "1.3.1",
+						"istanbul-lib-coverage": "1.2.0",
+						"istanbul-lib-instrument": "1.10.1",
+						"istanbul-lib-source-maps": "1.2.3",
+						"jest-changed-files": "22.4.3",
+						"jest-config": "22.4.4",
+						"jest-environment-jsdom": "22.4.3",
+						"jest-get-type": "22.4.3",
+						"jest-haste-map": "22.4.3",
+						"jest-message-util": "22.4.3",
+						"jest-regex-util": "22.4.3",
+						"jest-resolve-dependencies": "22.4.3",
+						"jest-runner": "22.4.4",
+						"jest-runtime": "22.4.4",
+						"jest-snapshot": "22.4.3",
+						"jest-util": "22.4.3",
+						"jest-validate": "22.4.4",
+						"jest-worker": "22.4.3",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.2.1",
+						"realpath-native": "1.0.0",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.0",
+						"yargs": "10.1.2"
 					}
 				},
 				"kind-of": {
@@ -6973,7 +6972,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -6982,19 +6981,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"strip-ansi": {
@@ -7003,7 +7002,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"yargs": {
@@ -7012,18 +7011,18 @@
 					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^8.1.0"
+						"cliui": "4.0.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -7032,7 +7031,7 @@
 					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -7043,7 +7042,7 @@
 			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
 			"dev": true,
 			"requires": {
-				"throat": "^4.0.0"
+				"throat": "4.1.0"
 			}
 		},
 		"jest-config": {
@@ -7052,17 +7051,17 @@
 			"integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^22.4.1",
-				"jest-environment-node": "^22.4.1",
-				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^22.4.4",
-				"jest-regex-util": "^22.1.0",
-				"jest-resolve": "^22.4.2",
-				"jest-util": "^22.4.1",
-				"jest-validate": "^22.4.4",
-				"pretty-format": "^22.4.0"
+				"chalk": "2.3.2",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "22.4.3",
+				"jest-environment-node": "22.4.3",
+				"jest-get-type": "22.4.3",
+				"jest-jasmine2": "22.4.4",
+				"jest-regex-util": "22.4.3",
+				"jest-resolve": "22.4.3",
+				"jest-util": "22.4.3",
+				"jest-validate": "22.4.4",
+				"pretty-format": "22.4.3"
 			}
 		},
 		"jest-diff": {
@@ -7071,10 +7070,10 @@
 			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff": "^3.2.0",
-				"jest-get-type": "^22.4.3",
-				"pretty-format": "^22.4.3"
+				"chalk": "2.3.2",
+				"diff": "3.5.0",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "22.4.3"
 			}
 		},
 		"jest-docblock": {
@@ -7083,7 +7082,7 @@
 			"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "2.1.0"
 			}
 		},
 		"jest-environment-enzyme": {
@@ -7092,7 +7091,7 @@
 			"integrity": "sha1-mfUdf5iJGKlj3yhZsx4paW1/a+0=",
 			"dev": true,
 			"requires": {
-				"jest-environment-jsdom": "^22.4.1"
+				"jest-environment-jsdom": "22.4.3"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -7101,9 +7100,9 @@
 			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^22.4.3",
-				"jest-util": "^22.4.3",
-				"jsdom": "^11.5.1"
+				"jest-mock": "22.4.3",
+				"jest-util": "22.4.3",
+				"jsdom": "11.11.0"
 			}
 		},
 		"jest-environment-node": {
@@ -7112,8 +7111,8 @@
 			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^22.4.3",
-				"jest-util": "^22.4.3"
+				"jest-mock": "22.4.3",
+				"jest-util": "22.4.3"
 			}
 		},
 		"jest-enzyme": {
@@ -7122,9 +7121,9 @@
 			"integrity": "sha1-aWNJj4lVC/MVt1ARoHkMc9+Vhg0=",
 			"dev": true,
 			"requires": {
-				"enzyme-matchers": "^6.0.1",
-				"enzyme-to-json": "^3.3.0",
-				"jest-environment-enzyme": "^6.0.1"
+				"enzyme-matchers": "6.0.1",
+				"enzyme-to-json": "3.3.4",
+				"jest-environment-enzyme": "6.0.1"
 			}
 		},
 		"jest-get-type": {
@@ -7139,13 +7138,13 @@
 			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-docblock": "^22.4.3",
-				"jest-serializer": "^22.4.3",
-				"jest-worker": "^22.4.3",
-				"micromatch": "^2.3.11",
-				"sane": "^2.0.0"
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-docblock": "22.4.3",
+				"jest-serializer": "22.4.3",
+				"jest-worker": "22.4.3",
+				"micromatch": "2.3.11",
+				"sane": "2.5.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -7154,7 +7153,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -7169,9 +7168,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"expand-brackets": {
@@ -7180,7 +7179,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -7189,7 +7188,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"is-extglob": {
@@ -7204,7 +7203,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -7213,7 +7212,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -7222,19 +7221,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				}
 			}
@@ -7245,17 +7244,17 @@
 			"integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"co": "^4.6.0",
-				"expect": "^22.4.0",
-				"graceful-fs": "^4.1.11",
-				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^22.4.0",
-				"jest-matcher-utils": "^22.4.0",
-				"jest-message-util": "^22.4.0",
-				"jest-snapshot": "^22.4.0",
-				"jest-util": "^22.4.1",
-				"source-map-support": "^0.5.0"
+				"chalk": "2.3.2",
+				"co": "4.6.0",
+				"expect": "22.4.3",
+				"graceful-fs": "4.1.11",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "22.4.3",
+				"jest-matcher-utils": "22.4.3",
+				"jest-message-util": "22.4.3",
+				"jest-snapshot": "22.4.3",
+				"jest-util": "22.4.3",
+				"source-map-support": "0.5.6"
 			},
 			"dependencies": {
 				"source-map": {
@@ -7270,8 +7269,8 @@
 					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 					"dev": true,
 					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
+						"buffer-from": "1.0.0",
+						"source-map": "0.6.1"
 					}
 				}
 			}
@@ -7282,7 +7281,7 @@
 			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^22.4.3"
+				"pretty-format": "22.4.3"
 			}
 		},
 		"jest-matcher-utils": {
@@ -7291,9 +7290,9 @@
 			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.4.3",
-				"pretty-format": "^22.4.3"
+				"chalk": "2.3.2",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "22.4.3"
 			}
 		},
 		"jest-message-util": {
@@ -7302,11 +7301,11 @@
 			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.35",
-				"chalk": "^2.0.1",
-				"micromatch": "^2.3.11",
-				"slash": "^1.0.0",
-				"stack-utils": "^1.0.1"
+				"@babel/code-frame": "7.0.0-beta.42",
+				"chalk": "2.3.2",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -7315,7 +7314,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -7330,9 +7329,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"expand-brackets": {
@@ -7341,7 +7340,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -7350,7 +7349,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"is-extglob": {
@@ -7365,7 +7364,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -7374,7 +7373,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -7383,19 +7382,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				}
 			}
@@ -7418,8 +7417,8 @@
 			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "^1.11.2",
-				"chalk": "^2.0.1"
+				"browser-resolve": "1.11.2",
+				"chalk": "2.3.2"
 			}
 		},
 		"jest-resolve-dependencies": {
@@ -7428,7 +7427,7 @@
 			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "^22.4.3"
+				"jest-regex-util": "22.4.3"
 			}
 		},
 		"jest-runner": {
@@ -7437,17 +7436,17 @@
 			"integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
 			"dev": true,
 			"requires": {
-				"exit": "^0.1.2",
-				"jest-config": "^22.4.4",
-				"jest-docblock": "^22.4.0",
-				"jest-haste-map": "^22.4.2",
-				"jest-jasmine2": "^22.4.4",
-				"jest-leak-detector": "^22.4.0",
-				"jest-message-util": "^22.4.0",
-				"jest-runtime": "^22.4.4",
-				"jest-util": "^22.4.1",
-				"jest-worker": "^22.2.2",
-				"throat": "^4.0.0"
+				"exit": "0.1.2",
+				"jest-config": "22.4.4",
+				"jest-docblock": "22.4.3",
+				"jest-haste-map": "22.4.3",
+				"jest-jasmine2": "22.4.4",
+				"jest-leak-detector": "22.4.3",
+				"jest-message-util": "22.4.3",
+				"jest-runtime": "22.4.4",
+				"jest-util": "22.4.3",
+				"jest-worker": "22.4.3",
+				"throat": "4.1.0"
 			}
 		},
 		"jest-runtime": {
@@ -7456,26 +7455,26 @@
 			"integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-jest": "^22.4.4",
-				"babel-plugin-istanbul": "^4.1.5",
-				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^22.4.4",
-				"jest-haste-map": "^22.4.2",
-				"jest-regex-util": "^22.1.0",
-				"jest-resolve": "^22.4.2",
-				"jest-util": "^22.4.1",
-				"jest-validate": "^22.4.4",
-				"json-stable-stringify": "^1.0.1",
-				"micromatch": "^2.3.11",
-				"realpath-native": "^1.0.0",
-				"slash": "^1.0.0",
+				"babel-core": "6.26.3",
+				"babel-jest": "22.4.4",
+				"babel-plugin-istanbul": "4.1.6",
+				"chalk": "2.3.2",
+				"convert-source-map": "1.5.1",
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "22.4.4",
+				"jest-haste-map": "22.4.3",
+				"jest-regex-util": "22.4.3",
+				"jest-resolve": "22.4.3",
+				"jest-util": "22.4.3",
+				"jest-validate": "22.4.4",
+				"json-stable-stringify": "1.0.1",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.0",
+				"slash": "1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "^2.1.0",
-				"yargs": "^10.0.3"
+				"write-file-atomic": "2.3.0",
+				"yargs": "10.1.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -7484,7 +7483,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -7499,8 +7498,8 @@
 					"integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
 					"dev": true,
 					"requires": {
-						"babel-plugin-istanbul": "^4.1.5",
-						"babel-preset-jest": "^22.4.4"
+						"babel-plugin-istanbul": "4.1.6",
+						"babel-preset-jest": "22.4.4"
 					}
 				},
 				"babel-plugin-jest-hoist": {
@@ -7515,8 +7514,8 @@
 					"integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
 					"dev": true,
 					"requires": {
-						"babel-plugin-jest-hoist": "^22.4.4",
-						"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+						"babel-plugin-jest-hoist": "22.4.4",
+						"babel-plugin-syntax-object-rest-spread": "6.13.0"
 					}
 				},
 				"braces": {
@@ -7525,9 +7524,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"expand-brackets": {
@@ -7536,7 +7535,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -7545,7 +7544,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"is-extglob": {
@@ -7560,7 +7559,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -7569,7 +7568,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -7578,19 +7577,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"strip-bom": {
@@ -7605,9 +7604,9 @@
 					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.2"
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"signal-exit": "3.0.2"
 					}
 				},
 				"yargs": {
@@ -7616,18 +7615,18 @@
 					"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^8.1.0"
+						"cliui": "4.0.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "8.1.0"
 					}
 				},
 				"yargs-parser": {
@@ -7636,7 +7635,7 @@
 					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -7653,12 +7652,12 @@
 			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-diff": "^22.4.3",
-				"jest-matcher-utils": "^22.4.3",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^22.4.3"
+				"chalk": "2.3.2",
+				"jest-diff": "22.4.3",
+				"jest-matcher-utils": "22.4.3",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "22.4.3"
 			}
 		},
 		"jest-util": {
@@ -7667,13 +7666,13 @@
 			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
 			"dev": true,
 			"requires": {
-				"callsites": "^2.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.11",
-				"is-ci": "^1.0.10",
-				"jest-message-util": "^22.4.3",
-				"mkdirp": "^0.5.1",
-				"source-map": "^0.6.0"
+				"callsites": "2.0.0",
+				"chalk": "2.3.2",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.1.0",
+				"jest-message-util": "22.4.3",
+				"mkdirp": "0.5.1",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -7690,11 +7689,11 @@
 			"integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-config": "^22.4.4",
-				"jest-get-type": "^22.1.0",
-				"leven": "^2.1.0",
-				"pretty-format": "^22.4.0"
+				"chalk": "2.3.2",
+				"jest-config": "22.4.4",
+				"jest-get-type": "22.4.3",
+				"leven": "2.1.0",
+				"pretty-format": "22.4.3"
 			}
 		},
 		"jest-worker": {
@@ -7703,7 +7702,7 @@
 			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1"
+				"merge-stream": "1.0.1"
 			}
 		},
 		"js-tokens": {
@@ -7717,8 +7716,8 @@
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
 			}
 		},
 		"jsbn": {
@@ -7734,21 +7733,21 @@
 			"integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-flow-strip-types": "^6.8.0",
-				"babel-preset-es2015": "^6.9.0",
-				"babel-preset-stage-1": "^6.5.0",
-				"babel-register": "^6.9.0",
-				"babylon": "^7.0.0-beta.30",
-				"colors": "^1.1.2",
-				"flow-parser": "^0.*",
-				"lodash": "^4.13.1",
-				"micromatch": "^2.3.7",
-				"neo-async": "^2.5.0",
+				"babel-plugin-transform-flow-strip-types": "6.22.0",
+				"babel-preset-es2015": "6.24.1",
+				"babel-preset-stage-1": "6.24.1",
+				"babel-register": "6.26.0",
+				"babylon": "7.0.0-beta.44",
+				"colors": "1.3.0",
+				"flow-parser": "0.73.0",
+				"lodash": "4.17.10",
+				"micromatch": "2.3.11",
+				"neo-async": "2.5.1",
 				"node-dir": "0.1.8",
-				"nomnom": "^1.8.1",
-				"recast": "^0.14.1",
-				"temp": "^0.8.1",
-				"write-file-atomic": "^1.2.0"
+				"nomnom": "1.8.1",
+				"recast": "0.14.7",
+				"temp": "0.8.3",
+				"write-file-atomic": "1.3.4"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -7757,7 +7756,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -7772,9 +7771,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"expand-brackets": {
@@ -7783,7 +7782,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -7792,7 +7791,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"is-extglob": {
@@ -7807,7 +7806,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -7816,7 +7815,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -7825,19 +7824,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				}
 			}
@@ -7848,32 +7847,32 @@
 			"integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
 			"dev": true,
 			"requires": {
-				"abab": "^1.0.4",
-				"acorn": "^5.3.0",
-				"acorn-globals": "^4.1.0",
-				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": ">= 0.3.1 < 0.4.0",
-				"data-urls": "^1.0.0",
-				"domexception": "^1.0.0",
-				"escodegen": "^1.9.0",
-				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.2.0",
-				"nwsapi": "^2.0.0",
+				"abab": "1.0.4",
+				"acorn": "5.5.3",
+				"acorn-globals": "4.1.0",
+				"array-equal": "1.0.0",
+				"cssom": "0.3.2",
+				"cssstyle": "0.3.1",
+				"data-urls": "1.0.0",
+				"domexception": "1.0.1",
+				"escodegen": "1.9.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.3.0",
+				"nwsapi": "2.0.0",
 				"parse5": "4.0.0",
-				"pn": "^1.1.0",
-				"request": "^2.83.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.3",
-				"w3c-hr-time": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.1",
-				"ws": "^4.0.0",
-				"xml-name-validator": "^3.0.0"
+				"pn": "1.1.0",
+				"request": "2.87.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.3",
+				"whatwg-mimetype": "2.1.0",
+				"whatwg-url": "6.4.1",
+				"ws": "4.1.0",
+				"xml-name-validator": "3.0.0"
 			}
 		},
 		"jsesc": {
@@ -7912,7 +7911,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "~0.0.0"
+				"jsonify": "0.0.0"
 			}
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -7963,7 +7962,7 @@
 			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.0.3"
+				"array-includes": "3.0.3"
 			}
 		},
 		"keyv": {
@@ -8000,7 +7999,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"leb": {
@@ -8027,8 +8026,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"listr": {
@@ -8037,22 +8036,22 @@
 			"integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
 			"dev": true,
 			"requires": {
-				"@samverschueren/stream-to-observable": "^0.3.0",
-				"cli-truncate": "^0.2.1",
-				"figures": "^1.7.0",
-				"indent-string": "^2.1.0",
-				"is-observable": "^1.1.0",
-				"is-promise": "^2.1.0",
-				"is-stream": "^1.1.0",
-				"listr-silent-renderer": "^1.1.1",
-				"listr-update-renderer": "^0.4.0",
-				"listr-verbose-renderer": "^0.4.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^1.0.2",
-				"ora": "^0.2.3",
-				"p-map": "^1.1.1",
-				"rxjs": "^6.1.0",
-				"strip-ansi": "^3.0.1"
+				"@samverschueren/stream-to-observable": "0.3.0",
+				"cli-truncate": "0.2.1",
+				"figures": "1.7.0",
+				"indent-string": "2.1.0",
+				"is-observable": "1.1.0",
+				"is-promise": "2.1.0",
+				"is-stream": "1.1.0",
+				"listr-silent-renderer": "1.1.1",
+				"listr-update-renderer": "0.4.0",
+				"listr-verbose-renderer": "0.4.1",
+				"log-symbols": "1.0.2",
+				"log-update": "1.0.2",
+				"ora": "0.2.3",
+				"p-map": "1.2.0",
+				"rxjs": "6.2.0",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8067,11 +8066,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"figures": {
@@ -8080,8 +8079,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
 					}
 				},
 				"log-symbols": {
@@ -8090,7 +8089,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.0.0"
+						"chalk": "1.1.3"
 					}
 				},
 				"rxjs": {
@@ -8099,7 +8098,7 @@
 					"integrity": "sha512-qBzf5uu6eOKiCZuAE0SgZ0/Qp+l54oeVxFfC2t+mJ2SFI6IB8gmMdJHs5DUMu5kqifqcCtsKS2XHjhZu6RKvAw==",
 					"dev": true,
 					"requires": {
-						"tslib": "^1.9.0"
+						"tslib": "1.9.1"
 					}
 				},
 				"supports-color": {
@@ -8122,14 +8121,14 @@
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"elegant-spinner": "^1.0.1",
-				"figures": "^1.7.0",
-				"indent-string": "^3.0.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^1.0.2",
-				"strip-ansi": "^3.0.1"
+				"chalk": "1.1.3",
+				"cli-truncate": "0.2.1",
+				"elegant-spinner": "1.0.1",
+				"figures": "1.7.0",
+				"indent-string": "3.2.0",
+				"log-symbols": "1.0.2",
+				"log-update": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8144,11 +8143,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"figures": {
@@ -8157,8 +8156,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
 					}
 				},
 				"indent-string": {
@@ -8173,7 +8172,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.0.0"
+						"chalk": "1.1.3"
 					}
 				},
 				"supports-color": {
@@ -8190,10 +8189,10 @@
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"cli-cursor": "^1.0.2",
-				"date-fns": "^1.27.2",
-				"figures": "^1.7.0"
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"date-fns": "1.29.0",
+				"figures": "1.7.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -8208,11 +8207,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"cli-cursor": {
@@ -8221,7 +8220,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^1.0.1"
+						"restore-cursor": "1.0.1"
 					}
 				},
 				"figures": {
@@ -8230,8 +8229,8 @@
 					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 					"dev": true,
 					"requires": {
-						"escape-string-regexp": "^1.0.5",
-						"object-assign": "^4.1.0"
+						"escape-string-regexp": "1.0.5",
+						"object-assign": "4.1.1"
 					}
 				},
 				"onetime": {
@@ -8246,8 +8245,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
 					}
 				},
 				"supports-color": {
@@ -8264,11 +8263,11 @@
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -8291,9 +8290,9 @@
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"dev": true,
 			"requires": {
-				"big.js": "^3.1.3",
-				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"big.js": "3.2.0",
+				"emojis-list": "2.1.0",
+				"json5": "0.5.1"
 			}
 		},
 		"locate-path": {
@@ -8302,8 +8301,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -8324,9 +8323,9 @@
 			"integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
 			"dev": true,
 			"requires": {
-				"lodash.isarray": "^3.0.0",
-				"lodash.istypedarray": "^3.0.0",
-				"lodash.keys": "^3.0.0"
+				"lodash.isarray": "3.0.4",
+				"lodash.istypedarray": "3.0.6",
+				"lodash.keys": "3.1.2"
 			}
 		},
 		"lodash._bindcallback": {
@@ -8365,8 +8364,8 @@
 			"integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
 			"dev": true,
 			"requires": {
-				"lodash._baseisequal": "^3.0.0",
-				"lodash._bindcallback": "^3.0.0"
+				"lodash._baseisequal": "3.0.7",
+				"lodash._bindcallback": "3.0.1"
 			}
 		},
 		"lodash.istypedarray": {
@@ -8381,9 +8380,9 @@
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"dev": true,
 			"requires": {
-				"lodash._getnative": "^3.0.0",
-				"lodash.isarguments": "^3.0.0",
-				"lodash.isarray": "^3.0.0"
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
 			}
 		},
 		"lodash.sortby": {
@@ -8398,7 +8397,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "2.3.2"
 			}
 		},
 		"log-update": {
@@ -8407,8 +8406,8 @@
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^1.0.0",
-				"cli-cursor": "^1.0.2"
+				"ansi-escapes": "1.4.0",
+				"cli-cursor": "1.0.2"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -8423,7 +8422,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^1.0.1"
+						"restore-cursor": "1.0.1"
 					}
 				},
 				"onetime": {
@@ -8438,8 +8437,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
 					}
 				}
 			}
@@ -8456,8 +8455,8 @@
 			"integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
 			"dev": true,
 			"requires": {
-				"es6-symbol": "^3.1.1",
-				"object.assign": "^4.1.0"
+				"es6-symbol": "3.1.1",
+				"object.assign": "4.1.0"
 			}
 		},
 		"long": {
@@ -8477,7 +8476,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "^3.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"loud-rejection": {
@@ -8486,8 +8485,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"lowercase-keys": {
@@ -8502,8 +8501,8 @@
 			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"magic-string": {
@@ -8512,7 +8511,7 @@
 			"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
 			"dev": true,
 			"requires": {
-				"vlq": "^0.2.2"
+				"vlq": "0.2.3"
 			}
 		},
 		"make-dir": {
@@ -8521,7 +8520,7 @@
 			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			}
 		},
 		"makeerror": {
@@ -8530,7 +8529,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.x"
+				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
@@ -8551,7 +8550,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"md5.js": {
@@ -8560,8 +8559,8 @@
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"dev": true,
 			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
 			}
 		},
 		"media-typer": {
@@ -8576,7 +8575,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"mem-fs": {
@@ -8585,9 +8584,9 @@
 			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
 			"dev": true,
 			"requires": {
-				"through2": "^2.0.0",
-				"vinyl": "^1.1.0",
-				"vinyl-file": "^2.0.0"
+				"through2": "2.0.3",
+				"vinyl": "1.2.0",
+				"vinyl-file": "2.0.0"
 			}
 		},
 		"mem-fs-editor": {
@@ -8596,17 +8595,17 @@
 			"integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
 			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"deep-extend": "^0.5.1",
-				"ejs": "^2.5.9",
-				"glob": "^7.0.3",
-				"globby": "^8.0.0",
-				"isbinaryfile": "^3.0.2",
-				"mkdirp": "^0.5.0",
-				"multimatch": "^2.0.0",
-				"rimraf": "^2.2.8",
-				"through2": "^2.0.0",
-				"vinyl": "^2.0.1"
+				"commondir": "1.0.1",
+				"deep-extend": "0.5.1",
+				"ejs": "2.6.1",
+				"glob": "7.1.2",
+				"globby": "8.0.1",
+				"isbinaryfile": "3.0.2",
+				"mkdirp": "0.5.1",
+				"multimatch": "2.1.0",
+				"rimraf": "2.6.2",
+				"through2": "2.0.3",
+				"vinyl": "2.1.0"
 			},
 			"dependencies": {
 				"clone": {
@@ -8633,12 +8632,12 @@
 					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
 					"dev": true,
 					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
+						"clone": "2.1.1",
+						"clone-buffer": "1.0.0",
+						"clone-stats": "1.0.0",
+						"cloneable-readable": "1.1.2",
+						"remove-trailing-separator": "1.1.0",
+						"replace-ext": "1.0.0"
 					}
 				}
 			}
@@ -8649,8 +8648,8 @@
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
 			"requires": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
+				"errno": "0.1.7",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"meow": {
@@ -8659,16 +8658,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
 			}
 		},
 		"merge": {
@@ -8689,7 +8688,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.5"
 			}
 		},
 		"merge2": {
@@ -8710,19 +8709,19 @@
 			"integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"braces": "2.3.1",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"extglob": "2.0.4",
+				"fragment-cache": "0.2.1",
+				"kind-of": "6.0.2",
+				"nanomatch": "1.2.9",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"miller-rabin": {
@@ -8731,8 +8730,8 @@
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0"
 			}
 		},
 		"mime": {
@@ -8753,7 +8752,7 @@
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.33.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"mimic-fn": {
@@ -8786,7 +8785,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -8801,16 +8800,16 @@
 			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 			"dev": true,
 			"requires": {
-				"concat-stream": "^1.5.0",
-				"duplexify": "^3.4.2",
-				"end-of-stream": "^1.1.0",
-				"flush-write-stream": "^1.0.0",
-				"from2": "^2.1.0",
-				"parallel-transform": "^1.1.0",
-				"pump": "^2.0.1",
-				"pumpify": "^1.3.3",
-				"stream-each": "^1.1.0",
-				"through2": "^2.0.0"
+				"concat-stream": "1.6.1",
+				"duplexify": "3.6.0",
+				"end-of-stream": "1.4.1",
+				"flush-write-stream": "1.0.3",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "2.0.1",
+				"pumpify": "1.5.1",
+				"stream-each": "1.2.2",
+				"through2": "2.0.3"
 			}
 		},
 		"mixin-deep": {
@@ -8819,8 +8818,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -8829,7 +8828,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -8857,12 +8856,12 @@
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.1.1",
-				"copy-concurrently": "^1.0.0",
-				"fs-write-stream-atomic": "^1.0.8",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.4",
-				"run-queue": "^1.0.3"
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"run-queue": "1.0.3"
 			}
 		},
 		"ms": {
@@ -8877,8 +8876,8 @@
 			"integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
 			"dev": true,
 			"requires": {
-				"dns-packet": "^1.3.1",
-				"thunky": "^1.0.2"
+				"dns-packet": "1.3.1",
+				"thunky": "1.0.2"
 			}
 		},
 		"multicast-dns-service-types": {
@@ -8893,10 +8892,10 @@
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"dev": true,
 			"requires": {
-				"array-differ": "^1.0.0",
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"minimatch": "^3.0.0"
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
 			}
 		},
 		"mute-stream": {
@@ -8918,18 +8917,18 @@
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-odd": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"natural-compare": {
@@ -8944,10 +8943,10 @@
 			"integrity": "sha512-ioYYogSaZhFlCpRizQgY3UT3G1qFXmHGY/5ozoFE3dMfiCRAeJfh+IPE3/eh9gCZvqLhPCWb4bLt7Bqzo+1mLQ==",
 			"dev": true,
 			"requires": {
-				"nomnom": "~1.6.2",
-				"railroad-diagrams": "^1.0.0",
+				"nomnom": "1.6.2",
+				"railroad-diagrams": "1.0.0",
 				"randexp": "0.4.6",
-				"semver": "^5.4.1"
+				"semver": "5.5.0"
 			},
 			"dependencies": {
 				"colors": {
@@ -8962,8 +8961,8 @@
 					"integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
 					"dev": true,
 					"requires": {
-						"colors": "0.5.x",
-						"underscore": "~1.4.4"
+						"colors": "0.5.1",
+						"underscore": "1.4.4"
 					}
 				},
 				"underscore": {
@@ -9009,8 +9008,8 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
+				"encoding": "0.1.12",
+				"is-stream": "1.1.0"
 			}
 		},
 		"node-forge": {
@@ -9031,28 +9030,28 @@
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"dev": true,
 			"requires": {
-				"assert": "^1.1.1",
-				"browserify-zlib": "^0.2.0",
-				"buffer": "^4.3.0",
-				"console-browserify": "^1.1.0",
-				"constants-browserify": "^1.0.0",
-				"crypto-browserify": "^3.11.0",
-				"domain-browser": "^1.1.1",
-				"events": "^1.0.0",
-				"https-browserify": "^1.0.0",
-				"os-browserify": "^0.3.0",
+				"assert": "1.4.1",
+				"browserify-zlib": "0.2.0",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.12.0",
+				"domain-browser": "1.2.0",
+				"events": "1.1.1",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "^0.11.10",
-				"punycode": "^1.2.4",
-				"querystring-es3": "^0.2.0",
-				"readable-stream": "^2.3.3",
-				"stream-browserify": "^2.0.1",
-				"stream-http": "^2.7.2",
-				"string_decoder": "^1.0.0",
-				"timers-browserify": "^2.0.4",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.5",
+				"stream-browserify": "2.0.1",
+				"stream-http": "2.8.2",
+				"string_decoder": "1.0.3",
+				"timers-browserify": "2.0.10",
 				"tty-browserify": "0.0.0",
-				"url": "^0.11.0",
-				"util": "^0.10.3",
+				"url": "0.11.0",
+				"util": "0.10.3",
 				"vm-browserify": "0.0.4"
 			}
 		},
@@ -9062,10 +9061,10 @@
 			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 			"dev": true,
 			"requires": {
-				"growly": "^1.3.0",
-				"semver": "^5.4.1",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.0"
 			}
 		},
 		"nomnom": {
@@ -9074,8 +9073,8 @@
 			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
 			"dev": true,
 			"requires": {
-				"chalk": "~0.4.0",
-				"underscore": "~1.6.0"
+				"chalk": "0.4.0",
+				"underscore": "1.6.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -9090,9 +9089,9 @@
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "~1.0.0",
-						"has-color": "~0.1.0",
-						"strip-ansi": "~0.1.0"
+						"ansi-styles": "1.0.0",
+						"has-color": "0.1.7",
+						"strip-ansi": "0.1.1"
 					}
 				},
 				"strip-ansi": {
@@ -9109,10 +9108,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
 			}
 		},
 		"normalize-path": {
@@ -9121,7 +9120,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"normalize-url": {
@@ -9130,9 +9129,9 @@
 			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
 			"dev": true,
 			"requires": {
-				"prepend-http": "^2.0.0",
-				"query-string": "^5.0.1",
-				"sort-keys": "^2.0.0"
+				"prepend-http": "2.0.0",
+				"query-string": "5.1.1",
+				"sort-keys": "2.0.0"
 			}
 		},
 		"npm-run-path": {
@@ -9141,7 +9140,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"nth-check": {
@@ -9150,7 +9149,7 @@
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
 			"dev": true,
 			"requires": {
-				"boolbase": "~1.0.0"
+				"boolbase": "1.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -9182,9 +9181,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -9193,7 +9192,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -9202,7 +9201,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -9211,7 +9210,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"is-descriptor": {
@@ -9220,9 +9219,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -9239,7 +9238,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -9268,7 +9267,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			}
 		},
 		"object.assign": {
@@ -9277,10 +9276,10 @@
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
+				"define-properties": "1.1.2",
+				"function-bind": "1.1.1",
+				"has-symbols": "1.0.0",
+				"object-keys": "1.0.11"
 			}
 		},
 		"object.entries": {
@@ -9289,10 +9288,10 @@
 			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.6.1",
-				"function-bind": "^1.1.0",
-				"has": "^1.0.1"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0",
+				"function-bind": "1.1.1",
+				"has": "1.0.1"
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -9301,8 +9300,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0"
 			}
 		},
 		"object.omit": {
@@ -9311,8 +9310,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			}
 		},
 		"object.pick": {
@@ -9321,7 +9320,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"object.values": {
@@ -9330,10 +9329,10 @@
 			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.6.1",
-				"function-bind": "^1.1.0",
-				"has": "^1.0.1"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.10.0",
+				"function-bind": "1.1.1",
+				"has": "1.0.1"
 			}
 		},
 		"obuf": {
@@ -9363,7 +9362,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -9372,7 +9371,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"opn": {
@@ -9381,7 +9380,7 @@
 			"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
 			"dev": true,
 			"requires": {
-				"is-wsl": "^1.1.0"
+				"is-wsl": "1.1.0"
 			}
 		},
 		"optimist": {
@@ -9390,8 +9389,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
+				"minimist": "0.0.10",
+				"wordwrap": "0.0.3"
 			},
 			"dependencies": {
 				"minimist": {
@@ -9408,12 +9407,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -9430,10 +9429,10 @@
 			"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.1",
-				"cli-cursor": "^1.0.2",
-				"cli-spinners": "^0.1.2",
-				"object-assign": "^4.0.1"
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"cli-spinners": "0.1.2",
+				"object-assign": "4.1.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -9448,11 +9447,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"cli-cursor": {
@@ -9461,7 +9460,7 @@
 					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^1.0.1"
+						"restore-cursor": "1.0.1"
 					}
 				},
 				"onetime": {
@@ -9476,8 +9475,8 @@
 					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 					"dev": true,
 					"requires": {
-						"exit-hook": "^1.0.0",
-						"onetime": "^1.0.0"
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
 					}
 				},
 				"supports-color": {
@@ -9494,7 +9493,7 @@
 			"integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
 			"dev": true,
 			"requires": {
-				"url-parse": "~1.4.0"
+				"url-parse": "1.4.0"
 			}
 		},
 		"os-browserify": {
@@ -9515,9 +9514,9 @@
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -9532,9 +9531,9 @@
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.4",
-				"mkdirp": "^0.5.1",
-				"object-assign": "^4.1.0"
+				"graceful-fs": "4.1.11",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1"
 			}
 		},
 		"p-cancelable": {
@@ -9549,7 +9548,7 @@
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
 			"dev": true,
 			"requires": {
-				"p-reduce": "^1.0.0"
+				"p-reduce": "1.0.0"
 			}
 		},
 		"p-finally": {
@@ -9576,7 +9575,7 @@
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -9585,7 +9584,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.2.0"
 			}
 		},
 		"p-map": {
@@ -9606,7 +9605,7 @@
 			"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
 			"dev": true,
 			"requires": {
-				"p-finally": "^1.0.0"
+				"p-finally": "1.0.0"
 			}
 		},
 		"p-try": {
@@ -9627,9 +9626,9 @@
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 			"dev": true,
 			"requires": {
-				"cyclist": "~0.2.2",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.1.5"
+				"cyclist": "0.2.2",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"parse-asn1": {
@@ -9638,11 +9637,11 @@
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"dev": true,
 			"requires": {
-				"asn1.js": "^4.0.0",
-				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3"
+				"asn1.js": "4.10.1",
+				"browserify-aes": "1.2.0",
+				"create-hash": "1.2.0",
+				"evp_bytestokey": "1.0.3",
+				"pbkdf2": "3.0.16"
 			}
 		},
 		"parse-glob": {
@@ -9651,10 +9650,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -9669,7 +9668,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				}
 			}
@@ -9680,7 +9679,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "1.3.1"
 			}
 		},
 		"parse-passwd": {
@@ -9761,9 +9760,9 @@
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -9780,11 +9779,11 @@
 			"integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
 			"dev": true,
 			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.1",
+				"sha.js": "2.4.11"
 			}
 		},
 		"performance-now": {
@@ -9811,7 +9810,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"pkg-dir": {
@@ -9820,7 +9819,7 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "2.1.0"
 			}
 		},
 		"pluralize": {
@@ -9841,9 +9840,9 @@
 			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
 			"dev": true,
 			"requires": {
-				"async": "^1.5.2",
-				"debug": "^2.2.0",
-				"mkdirp": "0.5.x"
+				"async": "1.5.2",
+				"debug": "2.6.9",
+				"mkdirp": "0.5.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -9899,8 +9898,8 @@
 			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -9940,7 +9939,7 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "~2.0.3"
+				"asap": "2.0.6"
 			}
 		},
 		"promise-inflight": {
@@ -9954,9 +9953,9 @@
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
 			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
 			}
 		},
 		"proxy-addr": {
@@ -9965,7 +9964,7 @@
 			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
 			"dev": true,
 			"requires": {
-				"forwarded": "~0.1.2",
+				"forwarded": "0.1.2",
 				"ipaddr.js": "1.6.0"
 			}
 		},
@@ -9987,11 +9986,11 @@
 			"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.2.0",
+				"parse-asn1": "5.1.1",
+				"randombytes": "2.0.6"
 			}
 		},
 		"pump": {
@@ -10000,8 +9999,8 @@
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
 			}
 		},
 		"pumpify": {
@@ -10010,9 +10009,9 @@
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 			"dev": true,
 			"requires": {
-				"duplexify": "^3.6.0",
-				"inherits": "^2.0.3",
-				"pump": "^2.0.0"
+				"duplexify": "3.6.0",
+				"inherits": "2.0.3",
+				"pump": "2.0.1"
 			}
 		},
 		"punycode": {
@@ -10033,9 +10032,9 @@
 			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 			"dev": true,
 			"requires": {
-				"decode-uri-component": "^0.2.0",
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
+				"decode-uri-component": "0.2.0",
+				"object-assign": "4.1.1",
+				"strict-uri-encode": "1.1.0"
 			}
 		},
 		"querystring": {
@@ -10062,7 +10061,7 @@
 			"integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
 			"dev": true,
 			"requires": {
-				"performance-now": "^2.1.0"
+				"performance-now": "2.1.0"
 			}
 		},
 		"railroad-diagrams": {
@@ -10078,7 +10077,7 @@
 			"dev": true,
 			"requires": {
 				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"randomatic": {
@@ -10087,8 +10086,8 @@
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -10097,7 +10096,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -10108,7 +10107,7 @@
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.0"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"randomfill": {
@@ -10117,8 +10116,8 @@
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"dev": true,
 			"requires": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
+				"randombytes": "2.0.6",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"range-parser": {
@@ -10154,7 +10153,7 @@
 						"depd": "1.1.1",
 						"inherits": "2.0.3",
 						"setprototypeof": "1.0.3",
-						"statuses": ">= 1.3.1 < 2"
+						"statuses": "1.4.0"
 					}
 				},
 				"setprototypeof": {
@@ -10171,10 +10170,10 @@
 			"integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
 			"dev": true,
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-dom": {
@@ -10183,10 +10182,10 @@
 			"integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
 			"dev": true,
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-is": {
@@ -10201,10 +10200,10 @@
 			"integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
 			"dev": true,
 			"requires": {
-				"fbjs": "^0.8.16",
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0"
+				"fbjs": "0.8.16",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-redux": {
@@ -10213,12 +10212,12 @@
 			"integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
 			"dev": true,
 			"requires": {
-				"hoist-non-react-statics": "^2.5.0",
-				"invariant": "^2.0.0",
-				"lodash": "^4.17.5",
-				"lodash-es": "^4.17.5",
-				"loose-envify": "^1.1.0",
-				"prop-types": "^15.6.0"
+				"hoist-non-react-statics": "2.5.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.10",
+				"lodash-es": "4.17.8",
+				"loose-envify": "1.3.1",
+				"prop-types": "15.6.1"
 			}
 		},
 		"react-test-renderer": {
@@ -10227,10 +10226,10 @@
 			"integrity": "sha512-Seh1t9xFY6TKiV/hRlPzUkqX1xHOiKIMsctfU0cggo1ajsLjoIJFL520LlrxV+4/VIj+clrCeH6s/aVv/vTStg==",
 			"dev": true,
 			"requires": {
-				"fbjs": "^0.8.16",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.0",
-				"react-is": "^16.4.0"
+				"fbjs": "0.8.16",
+				"object-assign": "4.1.1",
+				"prop-types": "15.6.1",
+				"react-is": "16.4.0"
 			}
 		},
 		"read-chunk": {
@@ -10239,8 +10238,8 @@
 			"integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0",
-				"safe-buffer": "^5.1.1"
+				"pify": "3.0.0",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"read-pkg": {
@@ -10249,9 +10248,9 @@
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^1.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
 			}
 		},
 		"read-pkg-up": {
@@ -10260,8 +10259,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -10270,8 +10269,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-exists": {
@@ -10280,7 +10279,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				}
 			}
@@ -10291,13 +10290,13 @@
 			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.0.3",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"readdirp": {
@@ -10306,10 +10305,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"readable-stream": "^2.0.2",
-				"set-immediate-shim": "^1.0.1"
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.5",
+				"set-immediate-shim": "1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -10318,7 +10317,7 @@
 			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "^1.0.0"
+				"util.promisify": "1.0.0"
 			}
 		},
 		"recast": {
@@ -10328,9 +10327,9 @@
 			"dev": true,
 			"requires": {
 				"ast-types": "0.11.3",
-				"esprima": "~4.0.0",
-				"private": "~0.1.5",
-				"source-map": "~0.6.1"
+				"esprima": "4.0.0",
+				"private": "0.1.8",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -10347,7 +10346,7 @@
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"dev": true,
 			"requires": {
-				"resolve": "^1.1.6"
+				"resolve": "1.7.1"
 			}
 		},
 		"redent": {
@@ -10356,8 +10355,8 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
 			}
 		},
 		"redux": {
@@ -10366,10 +10365,10 @@
 			"integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.2.1",
-				"lodash-es": "^4.2.1",
-				"loose-envify": "^1.1.0",
-				"symbol-observable": "^1.0.3"
+				"lodash": "4.17.10",
+				"lodash-es": "4.17.8",
+				"loose-envify": "1.3.1",
+				"symbol-observable": "1.2.0"
 			},
 			"dependencies": {
 				"symbol-observable": {
@@ -10398,9 +10397,9 @@
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.18.0",
-				"babel-types": "^6.19.0",
-				"private": "^0.1.6"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"private": "0.1.8"
 			}
 		},
 		"regex-cache": {
@@ -10409,7 +10408,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"is-equal-shallow": "0.1.3"
 			}
 		},
 		"regex-not": {
@@ -10418,8 +10417,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regexpp": {
@@ -10434,9 +10433,9 @@
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"dev": true,
 			"requires": {
-				"regenerate": "^1.2.1",
-				"regjsgen": "^0.2.0",
-				"regjsparser": "^0.1.4"
+				"regenerate": "1.4.0",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
 			}
 		},
 		"regjsgen": {
@@ -10451,7 +10450,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "~0.5.0"
+				"jsesc": "0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -10486,7 +10485,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"replace-ext": {
@@ -10501,26 +10500,26 @@
 			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"tough-cookie": "~2.3.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.1",
+				"safe-buffer": "5.1.1",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
 			}
 		},
 		"request-promise-core": {
@@ -10529,7 +10528,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "4.17.10"
 			}
 		},
 		"request-promise-native": {
@@ -10539,8 +10538,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.4"
 			}
 		},
 		"require-directory": {
@@ -10561,8 +10560,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -10591,7 +10590,7 @@
 			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -10600,7 +10599,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			}
 		},
 		"resolve-dir": {
@@ -10609,8 +10608,8 @@
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.0",
-				"global-modules": "^1.0.0"
+				"expand-tilde": "2.0.2",
+				"global-modules": "1.0.0"
 			}
 		},
 		"resolve-from": {
@@ -10631,7 +10630,7 @@
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "^1.0.0"
+				"lowercase-keys": "1.0.1"
 			}
 		},
 		"restore-cursor": {
@@ -10640,8 +10639,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ret": {
@@ -10657,7 +10656,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"align-text": "^0.1.1"
+				"align-text": "0.1.4"
 			}
 		},
 		"rimraf": {
@@ -10666,7 +10665,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.2"
 			}
 		},
 		"ripemd160": {
@@ -10675,8 +10674,8 @@
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 			"dev": true,
 			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "3.0.4",
+				"inherits": "2.0.3"
 			}
 		},
 		"rollup": {
@@ -10686,7 +10685,7 @@
 			"dev": true,
 			"requires": {
 				"@types/estree": "0.0.39",
-				"@types/node": "*"
+				"@types/node": "10.1.4"
 			}
 		},
 		"rollup-plugin-babel": {
@@ -10695,7 +10694,7 @@
 			"integrity": "sha512-TGhQbliTZnRoUhd2214K3r4KJUBu9J1DPzcrAnkluVXOVrveU9OvAaYQ16KyOmujAoq+LMC1+x6YF2xBrU7t+g==",
 			"dev": true,
 			"requires": {
-				"rollup-pluginutils": "^1.5.0"
+				"rollup-pluginutils": "1.5.2"
 			}
 		},
 		"rollup-plugin-commonjs": {
@@ -10704,10 +10703,10 @@
 			"integrity": "sha512-g91ZZKZwTW7F7vL6jMee38I8coj/Q9GBdTmXXeFL7ldgC1Ky5WJvHgbKlAiXXTh762qvohhExwUgeQGFh9suGg==",
 			"dev": true,
 			"requires": {
-				"estree-walker": "^0.5.1",
-				"magic-string": "^0.22.4",
-				"resolve": "^1.5.0",
-				"rollup-pluginutils": "^2.0.1"
+				"estree-walker": "0.5.2",
+				"magic-string": "0.22.5",
+				"resolve": "1.7.1",
+				"rollup-pluginutils": "2.3.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -10716,7 +10715,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -10731,9 +10730,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"estree-walker": {
@@ -10748,7 +10747,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -10757,7 +10756,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"is-extglob": {
@@ -10772,7 +10771,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -10781,7 +10780,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -10790,19 +10789,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"rollup-pluginutils": {
@@ -10811,8 +10810,8 @@
 					"integrity": "sha512-xB6hsRsjdJdIYWEyYUJy/3ki5g69wrf0luHPGNK3ZSocV6HLNfio59l3dZ3TL4xUwEKgROhFi9jOCt6c5gfUWw==",
 					"dev": true,
 					"requires": {
-						"estree-walker": "^0.5.2",
-						"micromatch": "^2.3.11"
+						"estree-walker": "0.5.2",
+						"micromatch": "2.3.11"
 					}
 				}
 			}
@@ -10823,9 +10822,9 @@
 			"integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^2.0.0",
-				"is-module": "^1.0.0",
-				"resolve": "^1.1.6"
+				"builtin-modules": "2.0.0",
+				"is-module": "1.0.0",
+				"resolve": "1.7.1"
 			},
 			"dependencies": {
 				"builtin-modules": {
@@ -10842,9 +10841,9 @@
 			"integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
 			"dev": true,
 			"requires": {
-				"magic-string": "^0.22.4",
-				"minimatch": "^3.0.2",
-				"rollup-pluginutils": "^2.0.1"
+				"magic-string": "0.22.5",
+				"minimatch": "3.0.4",
+				"rollup-pluginutils": "2.3.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -10853,7 +10852,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -10868,9 +10867,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"estree-walker": {
@@ -10885,7 +10884,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -10894,7 +10893,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"is-extglob": {
@@ -10909,7 +10908,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -10918,7 +10917,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -10927,19 +10926,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"rollup-pluginutils": {
@@ -10948,8 +10947,8 @@
 					"integrity": "sha512-xB6hsRsjdJdIYWEyYUJy/3ki5g69wrf0luHPGNK3ZSocV6HLNfio59l3dZ3TL4xUwEKgROhFi9jOCt6c5gfUWw==",
 					"dev": true,
 					"requires": {
-						"estree-walker": "^0.5.2",
-						"micromatch": "^2.3.11"
+						"estree-walker": "0.5.2",
+						"micromatch": "2.3.11"
 					}
 				}
 			}
@@ -10960,8 +10959,8 @@
 			"integrity": "sha512-f6W31EQLzxSEYfN3x6/lyljHqXSoCjXKcTsnwz3evQvHgU1+qTzU2SE0SIG7tbAvaCewp2UaZ5x3k6nYsxOP9A==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.47",
-				"uglify-js": "^3.3.25"
+				"@babel/code-frame": "7.0.0-beta.49",
+				"uglify-js": "3.4.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -10979,9 +10978,9 @@
 					"integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
+						"chalk": "2.3.2",
+						"esutils": "2.0.2",
+						"js-tokens": "3.0.2"
 					}
 				},
 				"commander": {
@@ -11002,8 +11001,8 @@
 					"integrity": "sha512-Jcf5naPkX3rVPSQpRn9Vm6Rr572I1gTtR9LnqKgXjmOgfYQ/QS0V2WRStFR53Bdj520M66aCZqt9uzYXgtGrJQ==",
 					"dev": true,
 					"requires": {
-						"commander": "~2.15.0",
-						"source-map": "~0.6.1"
+						"commander": "2.15.1",
+						"source-map": "0.6.1"
 					}
 				}
 			}
@@ -11014,8 +11013,8 @@
 			"integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
 			"dev": true,
 			"requires": {
-				"estree-walker": "^0.2.1",
-				"minimatch": "^3.0.2"
+				"estree-walker": "0.2.1",
+				"minimatch": "3.0.4"
 			}
 		},
 		"rst-selector-parser": {
@@ -11024,8 +11023,8 @@
 			"integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
 			"dev": true,
 			"requires": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
+				"lodash.flattendeep": "4.4.0",
+				"nearley": "2.13.0"
 			}
 		},
 		"rsvp": {
@@ -11040,7 +11039,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"run-queue": {
@@ -11049,7 +11048,7 @@
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.1.1"
+				"aproba": "1.2.0"
 			}
 		},
 		"rx-lite": {
@@ -11064,7 +11063,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "*"
+				"rx-lite": "4.0.8"
 			}
 		},
 		"rxjs": {
@@ -11088,7 +11087,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"sane": {
@@ -11097,15 +11096,15 @@
 			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"dev": true,
 			"requires": {
-				"anymatch": "^2.0.0",
-				"capture-exit": "^1.2.0",
-				"exec-sh": "^0.2.0",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.3",
-				"micromatch": "^3.1.4",
-				"minimist": "^1.1.1",
-				"walker": "~1.0.5",
-				"watch": "~0.18.0"
+				"anymatch": "2.0.0",
+				"capture-exit": "1.2.0",
+				"exec-sh": "0.2.1",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.2.4",
+				"micromatch": "3.1.9",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
 			},
 			"dependencies": {
 				"fsevents": {
@@ -11115,8 +11114,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"nan": "^2.9.2",
-						"node-pre-gyp": "^0.10.0"
+						"nan": "2.10.0",
+						"node-pre-gyp": "0.10.0"
 					},
 					"dependencies": {
 						"abbrev": {
@@ -11142,8 +11141,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^2.0.6"
+								"delegates": "1.0.0",
+								"readable-stream": "2.3.6"
 							}
 						},
 						"balanced-match": {
@@ -11156,7 +11155,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"balanced-match": "^1.0.0",
+								"balanced-match": "1.0.0",
 								"concat-map": "0.0.1"
 							}
 						},
@@ -11220,7 +11219,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"minipass": "^2.2.1"
+								"minipass": "2.2.4"
 							}
 						},
 						"fs.realpath": {
@@ -11235,14 +11234,14 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"aproba": "^1.0.3",
-								"console-control-strings": "^1.0.0",
-								"has-unicode": "^2.0.0",
-								"object-assign": "^4.1.0",
-								"signal-exit": "^3.0.0",
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wide-align": "^1.1.0"
+								"aproba": "1.2.0",
+								"console-control-strings": "1.1.0",
+								"has-unicode": "2.0.1",
+								"object-assign": "4.1.1",
+								"signal-exit": "3.0.2",
+								"string-width": "1.0.2",
+								"strip-ansi": "3.0.1",
+								"wide-align": "1.1.2"
 							}
 						},
 						"glob": {
@@ -11251,12 +11250,12 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
+								"fs.realpath": "1.0.0",
+								"inflight": "1.0.6",
+								"inherits": "2.0.3",
+								"minimatch": "3.0.4",
+								"once": "1.4.0",
+								"path-is-absolute": "1.0.1"
 							}
 						},
 						"has-unicode": {
@@ -11271,7 +11270,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"safer-buffer": "^2.1.0"
+								"safer-buffer": "2.1.2"
 							}
 						},
 						"ignore-walk": {
@@ -11280,7 +11279,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"minimatch": "^3.0.4"
+								"minimatch": "3.0.4"
 							}
 						},
 						"inflight": {
@@ -11289,8 +11288,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"once": "^1.3.0",
-								"wrappy": "1"
+								"once": "1.4.0",
+								"wrappy": "1.0.2"
 							}
 						},
 						"inherits": {
@@ -11309,7 +11308,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"number-is-nan": "^1.0.0"
+								"number-is-nan": "1.0.1"
 							}
 						},
 						"isarray": {
@@ -11323,7 +11322,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"brace-expansion": "^1.1.7"
+								"brace-expansion": "1.1.11"
 							}
 						},
 						"minimist": {
@@ -11336,8 +11335,8 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"safe-buffer": "^5.1.1",
-								"yallist": "^3.0.0"
+								"safe-buffer": "5.1.1",
+								"yallist": "3.0.2"
 							}
 						},
 						"minizlib": {
@@ -11346,7 +11345,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"minipass": "^2.2.1"
+								"minipass": "2.2.4"
 							}
 						},
 						"mkdirp": {
@@ -11369,9 +11368,9 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"debug": "^2.1.2",
-								"iconv-lite": "^0.4.4",
-								"sax": "^1.2.4"
+								"debug": "2.6.9",
+								"iconv-lite": "0.4.21",
+								"sax": "1.2.4"
 							}
 						},
 						"node-pre-gyp": {
@@ -11380,16 +11379,16 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"detect-libc": "^1.0.2",
-								"mkdirp": "^0.5.1",
-								"needle": "^2.2.0",
-								"nopt": "^4.0.1",
-								"npm-packlist": "^1.1.6",
-								"npmlog": "^4.0.2",
-								"rc": "^1.1.7",
-								"rimraf": "^2.6.1",
-								"semver": "^5.3.0",
-								"tar": "^4"
+								"detect-libc": "1.0.3",
+								"mkdirp": "0.5.1",
+								"needle": "2.2.0",
+								"nopt": "4.0.1",
+								"npm-packlist": "1.1.10",
+								"npmlog": "4.1.2",
+								"rc": "1.2.7",
+								"rimraf": "2.6.2",
+								"semver": "5.5.0",
+								"tar": "4.4.1"
 							}
 						},
 						"nopt": {
@@ -11398,8 +11397,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"abbrev": "1",
-								"osenv": "^0.1.4"
+								"abbrev": "1.1.1",
+								"osenv": "0.1.5"
 							}
 						},
 						"npm-bundled": {
@@ -11414,8 +11413,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"ignore-walk": "^3.0.1",
-								"npm-bundled": "^1.0.1"
+								"ignore-walk": "3.0.1",
+								"npm-bundled": "1.0.3"
 							}
 						},
 						"npmlog": {
@@ -11424,10 +11423,10 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"are-we-there-yet": "~1.1.2",
-								"console-control-strings": "~1.1.0",
-								"gauge": "~2.7.3",
-								"set-blocking": "~2.0.0"
+								"are-we-there-yet": "1.1.4",
+								"console-control-strings": "1.1.0",
+								"gauge": "2.7.4",
+								"set-blocking": "2.0.0"
 							}
 						},
 						"number-is-nan": {
@@ -11446,7 +11445,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"wrappy": "1"
+								"wrappy": "1.0.2"
 							}
 						},
 						"os-homedir": {
@@ -11467,8 +11466,8 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"os-homedir": "^1.0.0",
-								"os-tmpdir": "^1.0.0"
+								"os-homedir": "1.0.2",
+								"os-tmpdir": "1.0.2"
 							}
 						},
 						"path-is-absolute": {
@@ -11489,10 +11488,10 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"deep-extend": "^0.5.1",
-								"ini": "~1.3.0",
-								"minimist": "^1.2.0",
-								"strip-json-comments": "~2.0.1"
+								"deep-extend": "0.5.1",
+								"ini": "1.3.5",
+								"minimist": "1.2.0",
+								"strip-json-comments": "2.0.1"
 							},
 							"dependencies": {
 								"minimist": {
@@ -11509,13 +11508,13 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
+								"core-util-is": "1.0.2",
+								"inherits": "2.0.3",
+								"isarray": "1.0.0",
+								"process-nextick-args": "2.0.0",
+								"safe-buffer": "5.1.1",
+								"string_decoder": "1.1.1",
+								"util-deprecate": "1.0.2"
 							}
 						},
 						"rimraf": {
@@ -11524,7 +11523,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"glob": "^7.0.5"
+								"glob": "7.1.2"
 							}
 						},
 						"safe-buffer": {
@@ -11567,9 +11566,9 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						},
 						"string_decoder": {
@@ -11578,7 +11577,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.1"
 							}
 						},
 						"strip-ansi": {
@@ -11586,7 +11585,7 @@
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^2.0.0"
+								"ansi-regex": "2.1.1"
 							}
 						},
 						"strip-json-comments": {
@@ -11601,13 +11600,13 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"chownr": "^1.0.1",
-								"fs-minipass": "^1.2.5",
-								"minipass": "^2.2.4",
-								"minizlib": "^1.1.0",
-								"mkdirp": "^0.5.0",
-								"safe-buffer": "^5.1.1",
-								"yallist": "^3.0.2"
+								"chownr": "1.0.1",
+								"fs-minipass": "1.2.5",
+								"minipass": "2.2.4",
+								"minizlib": "1.1.0",
+								"mkdirp": "0.5.1",
+								"safe-buffer": "5.1.1",
+								"yallist": "3.0.2"
 							}
 						},
 						"util-deprecate": {
@@ -11622,7 +11621,7 @@
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"string-width": "^1.0.2"
+								"string-width": "1.0.2"
 							}
 						},
 						"wrappy": {
@@ -11651,8 +11650,8 @@
 			"integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0"
+				"ajv": "6.5.0",
+				"ajv-keywords": "3.2.0"
 			}
 		},
 		"scoped-regex": {
@@ -11689,18 +11688,18 @@
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
+				"depd": "1.1.2",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
+				"http-errors": "1.6.3",
 				"mime": "1.4.1",
 				"ms": "2.0.0",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.4.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -11726,13 +11725,13 @@
 			"integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
 			"dev": true,
 			"requires": {
-				"accepts": "~1.3.4",
+				"accepts": "1.3.5",
 				"batch": "0.6.1",
 				"debug": "2.6.9",
-				"escape-html": "~1.0.3",
-				"http-errors": "~1.6.2",
-				"mime-types": "~2.1.17",
-				"parseurl": "~1.3.2"
+				"escape-html": "1.0.3",
+				"http-errors": "1.6.3",
+				"mime-types": "2.1.18",
+				"parseurl": "1.3.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -11752,9 +11751,9 @@
 			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
 			"dev": true,
 			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
 				"send": "0.16.2"
 			}
 		},
@@ -11776,10 +11775,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -11788,7 +11787,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -11810,8 +11809,8 @@
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.3",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"shebang-command": {
@@ -11820,7 +11819,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -11835,9 +11834,9 @@
 			"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.0",
-				"interpret": "^1.0.0",
-				"rechoir": "^0.6.2"
+				"glob": "7.1.2",
+				"interpret": "1.1.0",
+				"rechoir": "0.6.2"
 			}
 		},
 		"shellwords": {
@@ -11876,14 +11875,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.1",
+				"use": "3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -11901,7 +11900,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -11910,7 +11909,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -11919,7 +11918,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11928,7 +11927,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -11939,7 +11938,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11948,7 +11947,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -11959,9 +11958,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					}
 				},
 				"kind-of": {
@@ -11978,9 +11977,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -11989,7 +11988,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				}
 			}
@@ -12000,7 +11999,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -12009,7 +12008,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -12020,8 +12019,8 @@
 			"integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
 			"dev": true,
 			"requires": {
-				"faye-websocket": "^0.10.0",
-				"uuid": "^3.0.1"
+				"faye-websocket": "0.10.0",
+				"uuid": "3.2.1"
 			}
 		},
 		"sockjs-client": {
@@ -12030,12 +12029,12 @@
 			"integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.6",
+				"debug": "2.6.9",
 				"eventsource": "0.1.6",
-				"faye-websocket": "~0.11.0",
-				"inherits": "^2.0.1",
-				"json3": "^3.3.2",
-				"url-parse": "^1.1.8"
+				"faye-websocket": "0.11.1",
+				"inherits": "2.0.3",
+				"json3": "3.3.2",
+				"url-parse": "1.4.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -12053,7 +12052,7 @@
 					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
 					"dev": true,
 					"requires": {
-						"websocket-driver": ">=0.5.1"
+						"websocket-driver": "0.7.0"
 					}
 				}
 			}
@@ -12064,7 +12063,7 @@
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "^1.0.0"
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"source-list-map": {
@@ -12085,11 +12084,11 @@
 			"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
 			"dev": true,
 			"requires": {
-				"atob": "^2.0.0",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.0.3",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -12098,7 +12097,7 @@
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"dev": true,
 			"requires": {
-				"source-map": "^0.5.6"
+				"source-map": "0.5.7"
 			}
 		},
 		"source-map-url": {
@@ -12113,8 +12112,8 @@
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -12129,8 +12128,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -12145,12 +12144,12 @@
 			"integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"handle-thing": "^1.2.5",
-				"http-deceiver": "^1.2.7",
-				"safe-buffer": "^5.0.1",
-				"select-hose": "^2.0.0",
-				"spdy-transport": "^2.0.18"
+				"debug": "2.6.9",
+				"handle-thing": "1.2.5",
+				"http-deceiver": "1.2.7",
+				"safe-buffer": "5.1.1",
+				"select-hose": "2.0.0",
+				"spdy-transport": "2.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -12170,13 +12169,13 @@
 			"integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"detect-node": "^2.0.3",
-				"hpack.js": "^2.1.6",
-				"obuf": "^1.1.1",
-				"readable-stream": "^2.2.9",
-				"safe-buffer": "^5.0.1",
-				"wbuf": "^1.7.2"
+				"debug": "2.6.9",
+				"detect-node": "2.0.3",
+				"hpack.js": "2.1.6",
+				"obuf": "1.1.2",
+				"readable-stream": "2.3.5",
+				"safe-buffer": "5.1.1",
+				"wbuf": "1.7.3"
 			},
 			"dependencies": {
 				"debug": {
@@ -12196,7 +12195,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -12211,14 +12210,14 @@
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"ssri": {
@@ -12227,7 +12226,7 @@
 			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.1"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"stack-utils": {
@@ -12242,8 +12241,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -12252,7 +12251,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -12261,7 +12260,7 @@
 					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -12270,7 +12269,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -12281,7 +12280,7 @@
 					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -12290,7 +12289,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -12301,9 +12300,9 @@
 					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
+						"is-accessor-descriptor": "0.1.6",
+						"is-data-descriptor": "0.1.4",
+						"kind-of": "5.1.0"
 					}
 				},
 				"kind-of": {
@@ -12332,8 +12331,8 @@
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
 			"requires": {
-				"inherits": "~2.0.1",
-				"readable-stream": "^2.0.2"
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.5"
 			}
 		},
 		"stream-each": {
@@ -12342,8 +12341,8 @@
 			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.1.0",
-				"stream-shift": "^1.0.0"
+				"end-of-stream": "1.4.1",
+				"stream-shift": "1.0.0"
 			}
 		},
 		"stream-http": {
@@ -12352,11 +12351,11 @@
 			"integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.3.6",
-				"to-arraybuffer": "^1.0.0",
-				"xtend": "^4.0.0"
+				"builtin-status-codes": "3.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6",
+				"to-arraybuffer": "1.0.1",
+				"xtend": "4.0.1"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -12365,13 +12364,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -12380,7 +12379,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.1"
 					}
 				}
 			}
@@ -12403,8 +12402,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -12419,7 +12418,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -12436,8 +12435,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -12458,7 +12457,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -12469,7 +12468,7 @@
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"strip-ansi": {
@@ -12478,7 +12477,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"strip-bom": {
@@ -12487,7 +12486,7 @@
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "^0.2.0"
+				"is-utf8": "0.2.1"
 			}
 		},
 		"strip-bom-stream": {
@@ -12496,8 +12495,8 @@
 			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
 			"dev": true,
 			"requires": {
-				"first-chunk-stream": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"first-chunk-stream": "2.0.0",
+				"strip-bom": "2.0.0"
 			}
 		},
 		"strip-eof": {
@@ -12512,7 +12511,7 @@
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "^4.0.1"
+				"get-stdin": "4.0.1"
 			}
 		},
 		"strip-json-comments": {
@@ -12527,7 +12526,7 @@
 			"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "3.0.0"
 			}
 		},
 		"symbol-observable": {
@@ -12548,12 +12547,12 @@
 			"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.2.3",
-				"ajv-keywords": "^2.1.0",
-				"chalk": "^2.1.0",
-				"lodash": "^4.17.4",
+				"ajv": "5.5.2",
+				"ajv-keywords": "2.1.1",
+				"chalk": "2.3.2",
+				"lodash": "4.17.10",
 				"slice-ansi": "1.0.0",
-				"string-width": "^2.1.1"
+				"string-width": "2.1.1"
 			},
 			"dependencies": {
 				"ajv": {
@@ -12562,10 +12561,10 @@
 					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
+						"co": "4.6.0",
+						"fast-deep-equal": "1.1.0",
+						"fast-json-stable-stringify": "2.0.0",
+						"json-schema-traverse": "0.3.1"
 					}
 				},
 				"ajv-keywords": {
@@ -12586,7 +12585,7 @@
 					"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0"
+						"is-fullwidth-code-point": "2.0.0"
 					}
 				}
 			}
@@ -12603,8 +12602,8 @@
 			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "^1.0.0",
-				"rimraf": "~2.2.6"
+				"os-tmpdir": "1.0.2",
+				"rimraf": "2.2.8"
 			},
 			"dependencies": {
 				"rimraf": {
@@ -12621,11 +12620,11 @@
 			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"micromatch": "^3.1.8",
-				"object-assign": "^4.1.0",
-				"read-pkg-up": "^1.0.1",
-				"require-main-filename": "^1.0.1"
+				"arrify": "1.0.1",
+				"micromatch": "3.1.9",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
 			}
 		},
 		"text-table": {
@@ -12658,8 +12657,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.1.5",
-				"xtend": "~4.0.1"
+				"readable-stream": "2.3.5",
+				"xtend": "4.0.1"
 			}
 		},
 		"thunky": {
@@ -12680,7 +12679,7 @@
 			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 			"dev": true,
 			"requires": {
-				"setimmediate": "^1.0.4"
+				"setimmediate": "1.0.5"
 			}
 		},
 		"tmp": {
@@ -12689,7 +12688,7 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"tmpl": {
@@ -12716,7 +12715,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -12725,7 +12724,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -12736,10 +12735,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -12748,8 +12747,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"tough-cookie": {
@@ -12758,7 +12757,7 @@
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"dev": true,
 			"requires": {
-				"punycode": "^1.4.1"
+				"punycode": "1.4.1"
 			}
 		},
 		"tr46": {
@@ -12767,7 +12766,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -12808,7 +12807,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"tweetnacl": {
@@ -12824,7 +12823,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"type-is": {
@@ -12834,7 +12833,7 @@
 			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "~2.1.18"
+				"mime-types": "2.1.18"
 			}
 		},
 		"typedarray": {
@@ -12854,8 +12853,8 @@
 			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
 			"dev": true,
 			"requires": {
-				"commander": "~2.13.0",
-				"source-map": "~0.6.1"
+				"commander": "2.13.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12879,14 +12878,14 @@
 			"integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
 			"dev": true,
 			"requires": {
-				"cacache": "^10.0.4",
-				"find-cache-dir": "^1.0.0",
-				"schema-utils": "^0.4.5",
-				"serialize-javascript": "^1.4.0",
-				"source-map": "^0.6.1",
-				"uglify-es": "^3.3.4",
-				"webpack-sources": "^1.1.0",
-				"worker-farm": "^1.5.2"
+				"cacache": "10.0.4",
+				"find-cache-dir": "1.0.0",
+				"schema-utils": "0.4.5",
+				"serialize-javascript": "1.5.0",
+				"source-map": "0.6.1",
+				"uglify-es": "3.3.9",
+				"webpack-sources": "1.1.0",
+				"worker-farm": "1.6.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12909,10 +12908,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -12921,7 +12920,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"set-value": {
@@ -12930,10 +12929,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
 					}
 				}
 			}
@@ -12944,7 +12943,7 @@
 			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
 			"dev": true,
 			"requires": {
-				"unique-slug": "^2.0.0"
+				"unique-slug": "2.0.0"
 			}
 		},
 		"unique-slug": {
@@ -12953,7 +12952,7 @@
 			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 			"dev": true,
 			"requires": {
-				"imurmurhash": "^0.1.4"
+				"imurmurhash": "0.1.4"
 			}
 		},
 		"unpipe": {
@@ -12968,8 +12967,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -12978,9 +12977,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -13020,7 +13019,7 @@
 			"integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -13067,8 +13066,8 @@
 			"integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
 			"dev": true,
 			"requires": {
-				"querystringify": "^2.0.0",
-				"requires-port": "^1.0.0"
+				"querystringify": "2.0.0",
+				"requires-port": "1.0.0"
 			}
 		},
 		"url-parse-lax": {
@@ -13077,7 +13076,7 @@
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "^2.0.0"
+				"prepend-http": "2.0.0"
 			}
 		},
 		"url-to-options": {
@@ -13098,7 +13097,7 @@
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.2"
+				"kind-of": "6.0.2"
 			}
 		},
 		"user-home": {
@@ -13136,8 +13135,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "1.1.2",
+				"object.getownpropertydescriptors": "2.0.3"
 			}
 		},
 		"utils-merge": {
@@ -13164,7 +13163,7 @@
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
 			"dev": true,
 			"requires": {
-				"user-home": "^1.1.1"
+				"user-home": "1.1.1"
 			}
 		},
 		"validate-npm-package-license": {
@@ -13173,8 +13172,8 @@
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"vary": {
@@ -13189,9 +13188,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"vinyl": {
@@ -13200,8 +13199,8 @@
 			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 			"dev": true,
 			"requires": {
-				"clone": "^1.0.0",
-				"clone-stats": "^0.0.1",
+				"clone": "1.0.4",
+				"clone-stats": "0.0.1",
 				"replace-ext": "0.0.1"
 			}
 		},
@@ -13211,12 +13210,12 @@
 			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.3.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0",
-				"strip-bom-stream": "^2.0.0",
-				"vinyl": "^1.1.0"
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "2.0.0",
+				"vinyl": "1.2.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -13248,7 +13247,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "^0.1.2"
+				"browser-process-hrtime": "0.1.2"
 			}
 		},
 		"walker": {
@@ -13257,7 +13256,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.x"
+				"makeerror": "1.0.11"
 			}
 		},
 		"watch": {
@@ -13266,8 +13265,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "^0.2.0",
-				"minimist": "^1.2.0"
+				"exec-sh": "0.2.1",
+				"minimist": "1.2.0"
 			}
 		},
 		"watchpack": {
@@ -13276,9 +13275,9 @@
 			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0"
+				"chokidar": "2.0.3",
+				"graceful-fs": "4.1.11",
+				"neo-async": "2.5.1"
 			}
 		},
 		"wbuf": {
@@ -13287,7 +13286,7 @@
 			"integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
 			"dev": true,
 			"requires": {
-				"minimalistic-assert": "^1.0.0"
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"webassemblyjs": {
@@ -13300,7 +13299,7 @@
 				"@webassemblyjs/validation": "1.4.3",
 				"@webassemblyjs/wasm-parser": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
-				"long": "^3.2.0"
+				"long": "3.2.0"
 			}
 		},
 		"webidl-conversions": {
@@ -13318,25 +13317,25 @@
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/wasm-edit": "1.4.3",
 				"@webassemblyjs/wasm-parser": "1.4.3",
-				"acorn": "^5.0.0",
-				"acorn-dynamic-import": "^3.0.0",
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0",
-				"chrome-trace-event": "^0.1.1",
-				"enhanced-resolve": "^4.0.0",
-				"eslint-scope": "^3.7.1",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"micromatch": "^3.1.8",
-				"mkdirp": "~0.5.0",
-				"neo-async": "^2.5.0",
-				"node-libs-browser": "^2.0.0",
-				"schema-utils": "^0.4.4",
-				"tapable": "^1.0.0",
-				"uglifyjs-webpack-plugin": "^1.2.4",
-				"watchpack": "^1.5.0",
-				"webpack-sources": "^1.0.1"
+				"acorn": "5.5.3",
+				"acorn-dynamic-import": "3.0.0",
+				"ajv": "6.5.0",
+				"ajv-keywords": "3.2.0",
+				"chrome-trace-event": "0.1.3",
+				"enhanced-resolve": "4.0.0",
+				"eslint-scope": "3.7.1",
+				"loader-runner": "2.3.0",
+				"loader-utils": "1.1.0",
+				"memory-fs": "0.4.1",
+				"micromatch": "3.1.9",
+				"mkdirp": "0.5.1",
+				"neo-async": "2.5.1",
+				"node-libs-browser": "2.1.0",
+				"schema-utils": "0.4.5",
+				"tapable": "1.0.0",
+				"uglifyjs-webpack-plugin": "1.2.5",
+				"watchpack": "1.6.0",
+				"webpack-sources": "1.1.0"
 			}
 		},
 		"webpack-addons": {
@@ -13345,7 +13344,7 @@
 			"integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
 			"dev": true,
 			"requires": {
-				"jscodeshift": "^0.4.0"
+				"jscodeshift": "0.4.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -13354,7 +13353,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -13381,9 +13380,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.2"
 					}
 				},
 				"expand-brackets": {
@@ -13392,7 +13391,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -13401,7 +13400,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"is-extglob": {
@@ -13416,7 +13415,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"jscodeshift": {
@@ -13425,21 +13424,21 @@
 					"integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
 					"dev": true,
 					"requires": {
-						"async": "^1.5.0",
-						"babel-plugin-transform-flow-strip-types": "^6.8.0",
-						"babel-preset-es2015": "^6.9.0",
-						"babel-preset-stage-1": "^6.5.0",
-						"babel-register": "^6.9.0",
-						"babylon": "^6.17.3",
-						"colors": "^1.1.2",
-						"flow-parser": "^0.*",
-						"lodash": "^4.13.1",
-						"micromatch": "^2.3.7",
+						"async": "1.5.2",
+						"babel-plugin-transform-flow-strip-types": "6.22.0",
+						"babel-preset-es2015": "6.24.1",
+						"babel-preset-stage-1": "6.24.1",
+						"babel-register": "6.26.0",
+						"babylon": "6.18.0",
+						"colors": "1.3.0",
+						"flow-parser": "0.73.0",
+						"lodash": "4.17.10",
+						"micromatch": "2.3.11",
 						"node-dir": "0.1.8",
-						"nomnom": "^1.8.1",
-						"recast": "^0.12.5",
-						"temp": "^0.8.1",
-						"write-file-atomic": "^1.2.0"
+						"nomnom": "1.8.1",
+						"recast": "0.12.9",
+						"temp": "0.8.3",
+						"write-file-atomic": "1.3.4"
 					}
 				},
 				"kind-of": {
@@ -13448,7 +13447,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"micromatch": {
@@ -13457,19 +13456,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"recast": {
@@ -13479,10 +13478,10 @@
 					"dev": true,
 					"requires": {
 						"ast-types": "0.10.1",
-						"core-js": "^2.4.1",
-						"esprima": "~4.0.0",
-						"private": "~0.1.5",
-						"source-map": "~0.6.1"
+						"core-js": "2.5.3",
+						"esprima": "4.0.0",
+						"private": "0.1.8",
+						"source-map": "0.6.1"
 					}
 				},
 				"source-map": {
@@ -13499,32 +13498,32 @@
 			"integrity": "sha512-dcxBcTPhKczWHYE9jh8MoHGQFuJxfqshZ3XSNFZ8o34heVvkqNvSRbMKy17NML+XUea7CXLzHWDg7a0GsBp7Pg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
-				"cross-spawn": "^6.0.5",
-				"diff": "^3.5.0",
-				"enhanced-resolve": "^4.0.0",
-				"envinfo": "^5.7.0",
-				"glob-all": "^3.1.0",
-				"global-modules": "^1.0.0",
-				"got": "^8.3.1",
-				"import-local": "^1.0.0",
-				"inquirer": "^5.2.0",
-				"interpret": "^1.1.0",
-				"jscodeshift": "^0.5.0",
-				"listr": "^0.14.1",
-				"loader-utils": "^1.1.0",
-				"lodash": "^4.17.10",
-				"log-symbols": "^2.2.0",
-				"mkdirp": "^0.5.1",
-				"p-each-series": "^1.0.0",
-				"p-lazy": "^1.0.0",
-				"prettier": "^1.12.1",
-				"supports-color": "^5.4.0",
-				"v8-compile-cache": "^2.0.0",
-				"webpack-addons": "^1.1.5",
-				"yargs": "^11.1.0",
-				"yeoman-environment": "^2.1.1",
-				"yeoman-generator": "^2.0.5"
+				"chalk": "2.4.1",
+				"cross-spawn": "6.0.5",
+				"diff": "3.5.0",
+				"enhanced-resolve": "4.0.0",
+				"envinfo": "5.8.1",
+				"glob-all": "3.1.0",
+				"global-modules": "1.0.0",
+				"got": "8.3.1",
+				"import-local": "1.0.0",
+				"inquirer": "5.2.0",
+				"interpret": "1.1.0",
+				"jscodeshift": "0.5.0",
+				"listr": "0.14.1",
+				"loader-utils": "1.1.0",
+				"lodash": "4.17.10",
+				"log-symbols": "2.2.0",
+				"mkdirp": "0.5.1",
+				"p-each-series": "1.0.0",
+				"p-lazy": "1.0.0",
+				"prettier": "1.12.1",
+				"supports-color": "5.4.0",
+				"v8-compile-cache": "2.0.0",
+				"webpack-addons": "1.1.5",
+				"yargs": "11.1.0",
+				"yeoman-environment": "2.1.1",
+				"yeoman-generator": "2.0.5"
 			},
 			"dependencies": {
 				"chalk": {
@@ -13533,9 +13532,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
+						"ansi-styles": "3.2.1",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "5.4.0"
 					}
 				},
 				"cross-spawn": {
@@ -13544,11 +13543,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.4",
+						"path-key": "2.0.1",
+						"semver": "5.5.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
 					}
 				},
 				"supports-color": {
@@ -13557,7 +13556,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -13568,13 +13567,13 @@
 			"integrity": "sha512-I6Mmy/QjWU/kXwCSFGaiOoL5YEQIVmbb0o45xMoCyQAg/mClqZVTcsX327sPfekDyJWpCxb+04whNyLOIxpJdQ==",
 			"dev": true,
 			"requires": {
-				"loud-rejection": "^1.6.0",
-				"memory-fs": "~0.4.1",
-				"mime": "^2.1.0",
-				"path-is-absolute": "^1.0.0",
-				"range-parser": "^1.0.3",
-				"url-join": "^4.0.0",
-				"webpack-log": "^1.0.1"
+				"loud-rejection": "1.6.0",
+				"memory-fs": "0.4.1",
+				"mime": "2.3.1",
+				"path-is-absolute": "1.0.1",
+				"range-parser": "1.2.0",
+				"url-join": "4.0.0",
+				"webpack-log": "1.2.0"
 			},
 			"dependencies": {
 				"mime": {
@@ -13592,32 +13591,32 @@
 			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
-				"array-includes": "^3.0.3",
-				"bonjour": "^3.5.0",
-				"chokidar": "^2.0.0",
-				"compression": "^1.5.2",
-				"connect-history-api-fallback": "^1.3.0",
-				"debug": "^3.1.0",
-				"del": "^3.0.0",
-				"express": "^4.16.2",
-				"html-entities": "^1.2.0",
-				"http-proxy-middleware": "~0.18.0",
-				"import-local": "^1.0.0",
+				"array-includes": "3.0.3",
+				"bonjour": "3.5.0",
+				"chokidar": "2.0.3",
+				"compression": "1.7.2",
+				"connect-history-api-fallback": "1.5.0",
+				"debug": "3.1.0",
+				"del": "3.0.0",
+				"express": "4.16.3",
+				"html-entities": "1.2.1",
+				"http-proxy-middleware": "0.18.0",
+				"import-local": "1.0.0",
 				"internal-ip": "1.2.0",
-				"ip": "^1.1.5",
-				"killable": "^1.0.0",
-				"loglevel": "^1.4.1",
-				"opn": "^5.1.0",
-				"portfinder": "^1.0.9",
-				"selfsigned": "^1.9.1",
-				"serve-index": "^1.7.2",
+				"ip": "1.1.5",
+				"killable": "1.0.0",
+				"loglevel": "1.6.1",
+				"opn": "5.3.0",
+				"portfinder": "1.0.13",
+				"selfsigned": "1.10.3",
+				"serve-index": "1.9.1",
 				"sockjs": "0.3.19",
 				"sockjs-client": "1.1.4",
-				"spdy": "^3.4.1",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^5.1.0",
+				"spdy": "3.4.7",
+				"strip-ansi": "3.0.1",
+				"supports-color": "5.3.0",
 				"webpack-dev-middleware": "3.1.3",
-				"webpack-log": "^1.1.2",
+				"webpack-log": "1.2.0",
 				"yargs": "11.0.0"
 			},
 			"dependencies": {
@@ -13627,18 +13626,18 @@
 					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"cliui": "4.0.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.2",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
 					}
 				}
 			}
@@ -13649,10 +13648,10 @@
 			"integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.1.0",
-				"log-symbols": "^2.1.0",
-				"loglevelnext": "^1.0.1",
-				"uuid": "^3.1.0"
+				"chalk": "2.3.2",
+				"log-symbols": "2.2.0",
+				"loglevelnext": "1.0.5",
+				"uuid": "3.2.1"
 			}
 		},
 		"webpack-sources": {
@@ -13661,8 +13660,8 @@
 			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
 			"dev": true,
 			"requires": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
+				"source-list-map": "2.0.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -13679,8 +13678,8 @@
 			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
 			"dev": true,
 			"requires": {
-				"http-parser-js": ">=0.4.0",
-				"websocket-extensions": ">=0.1.1"
+				"http-parser-js": "0.4.13",
+				"websocket-extensions": "0.1.3"
 			}
 		},
 		"websocket-extensions": {
@@ -13715,9 +13714,9 @@
 			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"which": {
@@ -13726,7 +13725,7 @@
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -13754,7 +13753,7 @@
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
 			"dev": true,
 			"requires": {
-				"errno": "~0.1.7"
+				"errno": "0.1.7"
 			}
 		},
 		"wrap-ansi": {
@@ -13763,8 +13762,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"string-width": {
@@ -13773,9 +13772,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}
@@ -13792,7 +13791,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -13801,9 +13800,9 @@
 			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"slide": "^1.1.5"
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"slide": "1.1.6"
 			}
 		},
 		"ws": {
@@ -13812,8 +13811,8 @@
 			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "~1.0.0",
-				"safe-buffer": "~5.1.0"
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"xml-name-validator": {
@@ -13846,18 +13845,18 @@
 			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 			"dev": true,
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^9.0.2"
+				"cliui": "4.0.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.2",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "9.0.2"
 			}
 		},
 		"yargs-parser": {
@@ -13866,7 +13865,7 @@
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "4.1.0"
 			}
 		},
 		"yeoman-environment": {
@@ -13875,21 +13874,21 @@
 			"integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.5",
-				"debug": "^3.1.0",
-				"diff": "^3.3.1",
-				"escape-string-regexp": "^1.0.2",
-				"globby": "^8.0.1",
-				"grouped-queue": "^0.3.3",
-				"inquirer": "^5.2.0",
-				"is-scoped": "^1.0.0",
-				"lodash": "^4.17.10",
-				"log-symbols": "^2.1.0",
-				"mem-fs": "^1.1.0",
-				"strip-ansi": "^4.0.0",
-				"text-table": "^0.2.0",
-				"untildify": "^3.0.2"
+				"chalk": "2.3.2",
+				"cross-spawn": "6.0.5",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"globby": "8.0.1",
+				"grouped-queue": "0.3.3",
+				"inquirer": "5.2.0",
+				"is-scoped": "1.0.0",
+				"lodash": "4.17.10",
+				"log-symbols": "2.2.0",
+				"mem-fs": "1.1.3",
+				"strip-ansi": "4.0.0",
+				"text-table": "0.2.0",
+				"untildify": "3.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -13904,11 +13903,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.4",
+						"path-key": "2.0.1",
+						"semver": "5.5.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
 					}
 				},
 				"strip-ansi": {
@@ -13917,7 +13916,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -13928,31 +13927,31 @@
 			"integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
 			"dev": true,
 			"requires": {
-				"async": "^2.6.0",
-				"chalk": "^2.3.0",
-				"cli-table": "^0.3.1",
-				"cross-spawn": "^6.0.5",
-				"dargs": "^5.1.0",
-				"dateformat": "^3.0.3",
-				"debug": "^3.1.0",
-				"detect-conflict": "^1.0.0",
-				"error": "^7.0.2",
-				"find-up": "^2.1.0",
-				"github-username": "^4.0.0",
-				"istextorbinary": "^2.2.1",
-				"lodash": "^4.17.10",
-				"make-dir": "^1.1.0",
-				"mem-fs-editor": "^4.0.0",
-				"minimist": "^1.2.0",
-				"pretty-bytes": "^4.0.2",
-				"read-chunk": "^2.1.0",
-				"read-pkg-up": "^3.0.0",
-				"rimraf": "^2.6.2",
-				"run-async": "^2.0.0",
-				"shelljs": "^0.8.0",
-				"text-table": "^0.2.0",
-				"through2": "^2.0.0",
-				"yeoman-environment": "^2.0.5"
+				"async": "2.6.1",
+				"chalk": "2.3.2",
+				"cli-table": "0.3.1",
+				"cross-spawn": "6.0.5",
+				"dargs": "5.1.0",
+				"dateformat": "3.0.3",
+				"debug": "3.1.0",
+				"detect-conflict": "1.0.1",
+				"error": "7.0.2",
+				"find-up": "2.1.0",
+				"github-username": "4.1.0",
+				"istextorbinary": "2.2.1",
+				"lodash": "4.17.10",
+				"make-dir": "1.2.0",
+				"mem-fs-editor": "4.0.2",
+				"minimist": "1.2.0",
+				"pretty-bytes": "4.0.2",
+				"read-chunk": "2.1.0",
+				"read-pkg-up": "3.0.0",
+				"rimraf": "2.6.2",
+				"run-async": "2.3.0",
+				"shelljs": "0.8.2",
+				"text-table": "0.2.0",
+				"through2": "2.0.3",
+				"yeoman-environment": "2.1.1"
 			},
 			"dependencies": {
 				"async": {
@@ -13961,7 +13960,7 @@
 					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.17.10"
+						"lodash": "4.17.10"
 					}
 				},
 				"cross-spawn": {
@@ -13970,11 +13969,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.4",
+						"path-key": "2.0.1",
+						"semver": "5.5.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.0"
 					}
 				},
 				"load-json-file": {
@@ -13983,10 +13982,10 @@
 					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "4.0.0",
+						"pify": "3.0.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"parse-json": {
@@ -13995,8 +13994,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "1.3.1",
+						"json-parse-better-errors": "1.0.2"
 					}
 				},
 				"path-type": {
@@ -14005,7 +14004,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
+						"pify": "3.0.0"
 					}
 				},
 				"read-pkg": {
@@ -14014,9 +14013,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
+						"load-json-file": "4.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "3.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -14025,8 +14024,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "3.0.0"
 					}
 				},
 				"strip-bom": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
 		"build:umd": "cross-env BABEL_ENV=rollup NODE_ENV=development rollup -c -o dist/fresh-data.js",
 		"build:umd:min": "cross-env BABEL_ENV=rollup NODE_ENV=production rollup -c -o dist/fresh-data.min.js",
 		"build": "npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min",
-		"prepack": "npm run clean && npm run lint && npm test && npm run build"
+		"postinstall": "npm run clean && npm run build",
+		"prepublishOnly": "npm run clean && npm run lint && npm test && npm run build"
 	},
 	"peerDependencies": {
 		"debug": "^3.1.0",


### PR DESCRIPTION
This changes the prepack script to a prepublishOnly script because as
prepack, it was running on a dependency npm install.

It also updates the lockfile while we're at it.