### PR TITLE
withApiClient: Rename mapApiToProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ As of now, Fresh Data is geared toward [React](https://github.com/facebook/react
 Here's how you define the API data you need for a React Component.
 
 ```js
-function mapApiToProps( selectors, ownProps, state ) {
+function mapSelectorsToProps( selectors, ownProps, state ) {
 	const { getThing } = selectors;
 	const { thingId } = ownProps;
 
@@ -40,7 +40,7 @@ function getClientKey( props ) {
 	return props.myApiUri
 }
 
-export default withApiClient( 'MyApi', mapApiToProps, getClientKey )( MyReactComponent );
+export default withApiClient( 'MyApi', mapSelectorsToProps, getClientKey )( MyReactComponent );
 ```
 
 The `withApiClient` Higher Order Component works much like `connect` from [React Redux](https://github.com/reduxjs/react-redux).

--- a/examples/hello-world/src/Message.js
+++ b/examples/hello-world/src/Message.js
@@ -46,7 +46,7 @@ class Message extends React.Component {
 	}
 }
 
-function mapApiToProps( selectors ) {
+function mapSelectorsToProps( selectors ) {
 	const { getGreetings } = selectors;
 
 	const greetings = getGreetings( { freshness: 10 * SECOND } );
@@ -60,4 +60,4 @@ function getClientKey( ownProps ) {
 	return ownProps.clientKey;
 }
 
-export default withApiClient( 'test', mapApiToProps, getClientKey )( Message );
+export default withApiClient( 'test', mapSelectorsToProps, getClientKey )( Message );

--- a/examples/wp-rest-api/src/PostList.js
+++ b/examples/wp-rest-api/src/PostList.js
@@ -35,7 +35,7 @@ PostList.propTypes = {
 	posts: PropTypes.array,
 };
 
-function mapApiToProps( selectors ) {
+function mapSelectorsToProps( selectors ) {
 	const { getPosts } = selectors;
 	const posts = getPosts( { freshness: 5 * MINUTE, timeout: 3 * SECOND } );
 	return {
@@ -47,4 +47,4 @@ function getClientKey( ownProps ) {
 	return ownProps.siteUrl;
 }
 
-export default withApiClient( 'wp-rest-api', mapApiToProps, getClientKey )( PostList );
+export default withApiClient( 'wp-rest-api', mapSelectorsToProps, getClientKey )( PostList );

--- a/src/react-redux/__tests__/with-api-client.spec.js
+++ b/src/react-redux/__tests__/with-api-client.spec.js
@@ -5,11 +5,16 @@ import withApiClient from '../with-api-client';
 
 describe( 'withApiClient', () => {
 	class TestApi extends FreshDataApi {
+		static selectors = {
+			getThing: () => () => {
+				return { id: 1, color: 'red' };
+			},
+		};
 	}
 
 	let api;
 	let Component;
-	let mapApiToProps;
+	let mapSelectorsToProps;
 	let getClientKey;
 	let getApiClient;
 
@@ -22,7 +27,7 @@ describe( 'withApiClient', () => {
 			);
 		};
 
-		mapApiToProps = () => ( {} );
+		mapSelectorsToProps = () => ( {} );
 		getClientKey = ( { clientKey } ) => clientKey;
 
 		getApiClient = ( apiName, clientKey ) => {
@@ -33,31 +38,31 @@ describe( 'withApiClient', () => {
 	} );
 
 	it( 'should render wrapped component.', () => {
-		const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+		const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 		const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
 		expect( wrapper.find( '.test-span' ) ).toHaveLength( 1 );
 	} );
 
 	it( 'should set displayName for wrapped component with displayName.', () => {
 		Component.displayName = 'TestDisplayName';
-		const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+		const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 		expect( ComponentWithApiClient.displayName ).toBe( 'ApiClientConnect( TestDisplayName )' );
 	} );
 
 	it( 'should set displayName for wrapped component without displayName.', () => {
 		Component.displayName = null;
-		const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+		const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 		expect( ComponentWithApiClient.displayName ).toBe( 'ApiClientConnect( ' + Component.name + ' )' );
 	} );
 
 	it( 'should render wrapped component even without getApiClient in context.', () => {
-		const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+		const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 		const wrapper = mount( <ComponentWithApiClient clientKey="123" /> );
 		expect( wrapper.find( '.test-span' ) ).toHaveLength( 1 );
 	} );
 
 	it( 'should return null if wrapped component is not valid.', () => {
-		const result = withApiClient( 'test', mapApiToProps, getClientKey )( '' );
+		const result = withApiClient( 'test', mapSelectorsToProps, getClientKey )( '' );
 		expect( result ).toBeNull();
 	} );
 
@@ -66,7 +71,7 @@ describe( 'withApiClient', () => {
 			getClientKey = jest.fn();
 			getClientKey.mockReturnValue( '123' );
 
-			const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 			mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
 
 			expect( getClientKey ).toHaveBeenLastCalledWith( { clientKey: '123' } );
@@ -75,7 +80,7 @@ describe( 'withApiClient', () => {
 		it( 'should call getApiClient on mount.', () => {
 			const mockGetApiClient = jest.fn();
 			mockGetApiClient.mockReturnValue( getApiClient( 'test', '123' ) );
-			const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 			mount(
 				<ComponentWithApiClient clientKey="123" />,
 				{ context: { getApiClient: mockGetApiClient } }
@@ -89,7 +94,7 @@ describe( 'withApiClient', () => {
 			const mockGetApiClient = jest.fn();
 			mockGetApiClient.mockReturnValueOnce( getApiClient( 'test', '123' ) );
 			mockGetApiClient.mockReturnValueOnce( getApiClient( 'test', '456' ) );
-			const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 			const wrapper = mount(
 				<ComponentWithApiClient clientKey="123" />,
 				{ context: { getApiClient: mockGetApiClient } }
@@ -105,7 +110,7 @@ describe( 'withApiClient', () => {
 		} );
 
 		it( 'should set clientKey and client in state.', () => {
-			const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
 
 			wrapper.instance().updateClient( {}, {} );
@@ -119,7 +124,7 @@ describe( 'withApiClient', () => {
 			const apiClient = getApiClient( 'test', '123' );
 			apiClient.subscribe = jest.fn();
 
-			const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
 			const handleSubscriptionChange = wrapper.instance().handleSubscriptionChange;
 			const state = wrapper.instance().state;
@@ -134,7 +139,7 @@ describe( 'withApiClient', () => {
 			const apiClient = getApiClient( 'test', '123' );
 			apiClient.unsubscribe = jest.fn();
 
-			const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
 
 			const handleSubscriptionChange = wrapper.instance().handleSubscriptionChange;
@@ -149,7 +154,7 @@ describe( 'withApiClient', () => {
 		it( 'should update when ApiClient state changes.', () => {
 			const apiClient = getApiClient( 'test', '123' );
 
-			const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
 
 			const clientState = {
@@ -163,7 +168,7 @@ describe( 'withApiClient', () => {
 		it( 'should not update when ApiClient state is identical.', () => {
 			const apiClient = getApiClient( 'test', '123' );
 
-			const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
 
 			const clientState = {
@@ -181,7 +186,7 @@ describe( 'withApiClient', () => {
 			const apiClient1 = getApiClient( 'test', '123' );
 			const apiClient2 = getApiClient( 'test', '456' );
 
-			const ComponentWithApiClient = withApiClient( 'test', mapApiToProps, getClientKey )( Component );
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
 			const wrapper = mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
 			expect( wrapper.instance().state.clientState ).toBe( apiClient1.state );
 
@@ -199,8 +204,28 @@ describe( 'withApiClient', () => {
 		} );
 	} );
 
-	describe( '#mapApiToProps', () => {
-		it( 'should provide api selectors to mapApiToProps', () => {
+	describe( '#mapSelectorsToProps', () => {
+		it( 'should provide api selectors to mapSelectorsToProps', () => {
+			const thing = { id: 1, color: 'red' };
+			let expectedProps = { clientKey: '123' };
+
+			mapSelectorsToProps = ( selectors, ownProps ) => {
+				const { getThing } = selectors;
+				expect( getThing ).toBeInstanceOf( Function );
+				expect( ownProps ).toEqual( expectedProps );
+
+				const selectorProps = { thing };
+				expectedProps = { ...ownProps, ...selectorProps };
+				return selectorProps;
+			};
+
+			Component = ( props ) => {
+				expect( props ).toEqual( expectedProps );
+				return <span className="test-span">Testing</span>;
+			};
+
+			const ComponentWithApiClient = withApiClient( 'test', mapSelectorsToProps, getClientKey )( Component );
+			mount( <ComponentWithApiClient clientKey="123" />, { context: { getApiClient } } );
 		} );
 	} );
 } );

--- a/src/react-redux/with-api-client.js
+++ b/src/react-redux/with-api-client.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 const debug = debugFactory( 'fresh-data:with-api-client' );
 
-export default function withApiClient( apiName, mapApiToProps, getClientKey ) {
+export default function withApiClient( apiName, mapSelectorsToProps, getClientKey ) {
 	return function connectWithApiClient( WrappedComponent ) {
 		if ( typeof WrappedComponent !== 'function' ) {
 			debug(
@@ -87,7 +87,7 @@ export default function withApiClient( apiName, mapApiToProps, getClientKey ) {
 					client.setComponentData(
 						this,
 						( selectors ) => {
-							apiProps = mapApiToProps( selectors, this.props );
+							apiProps = mapSelectorsToProps( selectors, this.props );
 						}
 					);
 				}


### PR DESCRIPTION
Originally, mapApiToProps actually passed down the apiClient object, but
since it's been simplified to only pass down selectors, the name of the
callback function should be changed as well.

To Test:
1. `npm install`
2. `npm run test`