### PR TITLE
FreshDataApi: Add mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ export default class MyApi extends FreshDataApi {
 			const uri = clientKey + endpointPath.join( '/' );
 			const queryString = qs.stringify( params );
 			return fetch( `${ uri }?${ query }` );
+		},
+		put: ( clientKey ) => ( endpointPath ) => ( params ) => {
+			const uri = clientKey + endpointPath.join( '/' );
+			const { data } = params;
+			return fetch( uri, { method: 'PUT', body: JSON.stringify( data ) } );
 		}
 	}
 
@@ -66,15 +71,27 @@ export default class MyApi extends FreshDataApi {
 				const { get } = methods;
 				const fullEndpointPath = [ 'things', ...endpointPath ];
 				return get( fullEndpointPath )( params );
+			},
+			update: ( methods, endpointPath, params ) => {
+				const { put } = methods;
+				const fullEndpointPath = [ 'things', ...endpointPath ];
+				return put( fullEndpointPath )( params );
 			}
 		}
 	}
 
 	static selectors = {
 		getThing: ( getData, requireData ) => ( thingId, requirement ) => {
-			const path = [ 'thing', thingId ];
+			const path = [ 'things', thingId ];
 			requireData( requirement, path );
 			return getData( path ) || {};
+		}
+	}
+
+	static mutations = {
+		updateThing: ( methods, endpoints ) => ( thingId, data ) => {
+			const { update } = endpoints.things;
+			return update( methods, [ thingId ], { data } );
 		}
 	}
 }
@@ -110,10 +127,8 @@ export default MyApp = () => {
 Fresh Data is functional, but still a work in progress. Here's what's next on the list:
 - More examples:
   - GitHub API
-  - WordPress REST API
   - GraphQL
   - WebSockets
-  - Mutating data example (create, update, delete endpoints)
 - Feature: Fetch on first mount (regardless of freshness)
 - Feature: Clearing out old data
   - Detecting when data was last rendered

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ export default class MyApi extends FreshDataApi {
 	}
 
 	static mutations = {
-		updateThing: ( methods, endpoints ) => ( thingId, data ) => {
+		updateThing: ( operations ) => ( thingId, data ) => {
 			const { update } = endpoints.things;
-			return update( methods, [ thingId ], { data } );
+			return operations.update( methods, [ thingId ], { data } );
 		}
 	}
 }

--- a/src/api/__tests__/index.spec.js
+++ b/src/api/__tests__/index.spec.js
@@ -44,6 +44,15 @@ describe( 'api', () => {
 			const api = new MyApi();
 			expect( api.selectors ).toBe( selectors );
 		} );
+
+		it( 'should use mutation methods defined in subclass', () => {
+			const mutations = { getThings: () => () => {} };
+			class MyApi extends FreshDataApi {
+				static mutations = mutations;
+			}
+			const api = new MyApi();
+			expect( api.mutations ).toBe( mutations );
+		} );
 	} );
 
 	describe( '#setDataHandlers', () => {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -4,9 +4,12 @@ import ApiClient from '../client/index';
 const debug = debugFactory( 'fresh-data:api' );
 
 export default class FreshDataApi {
+	// TODO: Consider making these part of the instance instead of the class.
+	// It would allow the use of `this` to retrieve things like methods and endpoints.
 	static methods = {}
 	static endpoints = {}
 	static selectors = {}
+	static mutations = {}
 
 	constructor() {
 		this.clients = new Map();
@@ -17,6 +20,7 @@ export default class FreshDataApi {
 		this.methods = this.constructor.methods;
 		this.endpoints = this.constructor.endpoints;
 		this.selectors = this.constructor.selectors;
+		this.mutations = this.constructor.mutations;
 	}
 
 	setDataHandlers = ( dataRequested, dataReceived, errorReceived ) => {

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -86,6 +86,22 @@ describe( 'ApiClient', () => {
 		expect( checkMethod ).toHaveBeenCalledWith( 'post', '123', thing2Path, undefined );
 	} );
 
+	it( 'should map mutations to endpoints', () => {
+		const createThing = jest.fn();
+
+		class TestApi extends FreshDataApi {
+			static mutations = {
+				createThing,
+			};
+		}
+
+		const api = new TestApi();
+		const apiClient = new ApiClient( api, '123' );
+
+		expect( createThing ).toHaveBeenCalledTimes( 1 );
+		expect( createThing ).toHaveBeenCalledWith( apiClient.methods, api.endpoints );
+	} );
+
 	it( 'should map getData to current state', () => {
 		class TestApi extends FreshDataApi {
 			static selectors = thingSelectors;

--- a/src/client/__tests__/index.spec.js
+++ b/src/client/__tests__/index.spec.js
@@ -86,7 +86,7 @@ describe( 'ApiClient', () => {
 		expect( checkMethod ).toHaveBeenCalledWith( 'post', '123', thing2Path, undefined );
 	} );
 
-	it( 'should map mutations to endpoints', () => {
+	it( 'should map mutations to endpoint operations', () => {
 		const createThing = jest.fn();
 
 		class TestApi extends FreshDataApi {
@@ -99,7 +99,7 @@ describe( 'ApiClient', () => {
 		const apiClient = new ApiClient( api, '123' );
 
 		expect( createThing ).toHaveBeenCalledTimes( 1 );
-		expect( createThing ).toHaveBeenCalledWith( apiClient.methods, api.endpoints );
+		expect( createThing ).toHaveBeenCalledWith( apiClient.endpointOperations );
 	} );
 
 	it( 'should map getData to current state', () => {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -25,6 +25,7 @@ export default class ApiClient {
 		this.requirementsByComponent = new Map();
 		this.requirementsByEndpoint = {};
 		this.methods = mapMethods( api.methods, key );
+		this.mutations = mapMutations( api.mutations, this.methods, api.endpoints );
 		this.minUpdate = DEFAULT_MIN_UPDATE;
 		this.maxUpdate = DEFAULT_MAX_UPDATE;
 		this.setTimer = setTimer;
@@ -65,6 +66,10 @@ export default class ApiClient {
 	getData = ( endpointPath, params ) => {
 		return getDataFromState( this.state )( endpointPath, params );
 	};
+
+	getMutations = () => {
+		return this.mutations;
+	}
 
 	setComponentData = ( component, selectorFunc, now = new Date() ) => {
 		if ( selectorFunc ) {
@@ -201,9 +206,16 @@ function mapMethods( methods, clientKey ) {
 	}, {} );
 }
 
+function mapMutations( mutations, methods, endpoints ) {
+	return Object.keys( mutations ).reduce( ( mappedMutations, mutationName ) => {
+		mappedMutations[ mutationName ] = mutations[ mutationName ]( methods, endpoints );
+		return mappedMutations;
+	}, {} );
+}
+
 function mapSelectors( selectors, clientGetData, clientRequireData ) {
 	return Object.keys( selectors ).reduce( ( mappedSelectors, selectorName ) => {
 		mappedSelectors[ selectorName ] = selectors[ selectorName ]( clientGetData, clientRequireData );
 		return mappedSelectors;
-	}, [] );
+	}, {} );
 }

--- a/src/react-redux/__tests__/with-api-client.spec.js
+++ b/src/react-redux/__tests__/with-api-client.spec.js
@@ -274,15 +274,15 @@ describe( 'withApiClient', () => {
 					things: {
 						update: ( methods, endpointPath, params ) => {
 							const { put } = methods;
-							put( endpointPath )( params );
+							const fullEndpointPath = [ 'things', ...endpointPath ];
+							put( fullEndpointPath )( params );
 						},
 					},
 				};
 				static mutations = {
-					updateThing: ( methods, endpoints ) => ( id, data ) => {
-						const { update } = endpoints.things;
+					updateThing: ( operations ) => ( id, data ) => {
 						updateFunc( id, data );
-						update( methods, [ 'things', id ], { testParam: true } );
+						operations.update( [ 'things', id ], { data } );
 					}
 				};
 			}
@@ -292,11 +292,11 @@ describe( 'withApiClient', () => {
 			let mutationProps = null;
 
 			mapMutationsToProps = ( mutations, ownProps ) => {
-				const { createThing, updateThing } = mutations;
+				const { updateThing } = mutations;
 				expect( updateThing ).toBeInstanceOf( Function );
 				expect( ownProps ).toEqual( expectedProps );
 
-				mutationProps = { createThing, updateThing };
+				mutationProps = { updateThing };
 				expectedProps = { ...ownProps, ...mutationProps };
 				return mutationProps;
 			};
@@ -315,7 +315,7 @@ describe( 'withApiClient', () => {
 			expect( updateFunc ).toHaveBeenCalledTimes( 1 );
 			expect( updateFunc ).toHaveBeenCalledWith( 1, { id: 1, color: 'red' } );
 			expect( putFunc ).toHaveBeenCalledTimes( 1 );
-			expect( putFunc ).toHaveBeenCalledWith( '123', [ 'things', 1 ], { testParam: true } );
+			expect( putFunc ).toHaveBeenCalledWith( '123', [ 'things', 1 ], { data: { id: 1, color: 'red' } } );
 		} );
 
 		it( 'should render without mapMutationsToProps.', () => {


### PR DESCRIPTION
This adds mutations to the api as a set of purpose-made mutations for
applications to use to send mutating operations to an API.

To Test:
1. `npm install`
2. `npm test`

No example code for testing mutations yet, but I'll be adding it to the wp plugin example next.
